### PR TITLE
feat: add JSON-RPC sidecar and Go client

### DIFF
--- a/aider-core/core/src/lib.rs
+++ b/aider-core/core/src/lib.rs
@@ -1,4 +1,5 @@
 use reqwest;
+use std::process::Command;
 use thiserror::Error;
 use tracing::info;
 
@@ -6,6 +7,8 @@ use tracing::info;
 pub enum CoreError {
     #[error("http error: {0}")]
     Http(#[from] reqwest::Error),
+    #[error("git error: {0}")]
+    Git(String),
 }
 
 pub async fn fetch(url: &str) -> Result<String, CoreError> {
@@ -16,4 +19,20 @@ pub async fn fetch(url: &str) -> Result<String, CoreError> {
 
 pub fn ping() -> &'static str {
     "pong"
+}
+
+pub fn git(args: Vec<String>) -> Result<String, CoreError> {
+    let output = Command::new("git")
+        .args(&args)
+        .output()
+        .map_err(|e| CoreError::Git(e.to_string()))?;
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+pub fn repo_map() -> String {
+    "repo map not implemented".to_string()
+}
+
+pub fn llm(prompt: String) -> String {
+    format!("LLM response to: {prompt}")
 }

--- a/aider-core/sidecar/src/main.rs
+++ b/aider-core/sidecar/src/main.rs
@@ -1,14 +1,109 @@
-use axum::{routing::get, Json, Router};
-use std::net::SocketAddr;
+use axum::{
+    Json, Router,
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    routing::{get, post},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::{env, net::SocketAddr};
 use tokio::net::TcpListener;
+
+#[derive(Clone)]
+struct AppState {
+    token: Option<String>,
+}
 
 async fn ping() -> Json<&'static str> {
     Json(aider_core::ping())
 }
 
+#[derive(Deserialize)]
+struct RpcRequest {
+    method: String,
+    params: Value,
+}
+
+#[derive(Serialize)]
+struct RpcResponse {
+    result: Option<Value>,
+    error: Option<String>,
+}
+
+impl RpcResponse {
+    fn result(v: Value) -> Self {
+        Self {
+            result: Some(v),
+            error: None,
+        }
+    }
+    fn error(msg: String) -> Self {
+        Self {
+            result: None,
+            error: Some(msg),
+        }
+    }
+}
+
+async fn rpc_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(req): Json<RpcRequest>,
+) -> (StatusCode, Json<RpcResponse>) {
+    if let Some(token) = &state.token {
+        match headers.get("authorization") {
+            Some(h) if h.to_str().ok() == Some(&format!("Bearer {token}")) => {}
+            _ => {
+                return (
+                    StatusCode::UNAUTHORIZED,
+                    Json(RpcResponse::error("unauthorized".into())),
+                );
+            }
+        }
+    }
+
+    let resp = match req.method.as_str() {
+        "git" => {
+            #[derive(Deserialize)]
+            struct GitParams {
+                args: Vec<String>,
+            }
+            let params: GitParams =
+                serde_json::from_value(req.params).unwrap_or(GitParams { args: vec![] });
+            match aider_core::git(params.args) {
+                Ok(out) => RpcResponse::result(Value::String(out)),
+                Err(e) => RpcResponse::error(e.to_string()),
+            }
+        }
+        "repo_map" => {
+            let map = aider_core::repo_map();
+            RpcResponse::result(Value::String(map))
+        }
+        "llm" => {
+            #[derive(Deserialize)]
+            struct LlmParams {
+                prompt: String,
+            }
+            let params: LlmParams = serde_json::from_value(req.params).unwrap_or(LlmParams {
+                prompt: String::new(),
+            });
+            let ans = aider_core::llm(params.prompt);
+            RpcResponse::result(Value::String(ans))
+        }
+        _ => RpcResponse::error("unknown method".into()),
+    };
+
+    (StatusCode::OK, Json(resp))
+}
+
 #[tokio::main]
 async fn main() {
-    let app = Router::new().route("/ping", get(ping));
+    let token = env::var("SIDECAR_TOKEN").ok();
+    let state = AppState { token };
+    let app = Router::new()
+        .route("/ping", get(ping))
+        .route("/rpc", post(rpc_handler))
+        .with_state(state);
     let addr = SocketAddr::from(([127, 0, 0, 1], 8080));
     println!("listening on {addr}");
     let listener = TcpListener::bind(addr).await.unwrap();

--- a/go-shell/sidecarclient/README.md
+++ b/go-shell/sidecarclient/README.md
@@ -1,0 +1,40 @@
+# Sidecar Client
+
+This package provides a Go client for the Rust sidecar using JSON-RPC over HTTP.
+Configuration values are loaded via `viper` and can be set through environment
+variables or config files:
+
+- `SIDECAR_HTTP` – base URL for HTTP requests (default `http://localhost:8080`)
+- `SIDECAR_WS` – base WebSocket URL (default `ws://localhost:8080`)
+- `SIDECAR_TOKEN` – optional bearer token for authentication
+
+## Example
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/aider-rs/go-shell/sidecarclient"
+)
+
+func main() {
+    client := sidecarclient.New()
+    ctx := context.Background()
+
+    out, err := client.Git(ctx, []string{"status"})
+    if err != nil { panic(err) }
+    fmt.Println(out)
+
+    resp, _ := client.LLM(ctx, "hello")
+    fmt.Println(resp)
+}
+```
+
+The JSON-RPC API supports the following methods:
+
+- `git` – execute git commands (`{ "args": ["status"] }`)
+- `repo_map` – return a repository map
+- `llm` – echo back a prompt (`{ "prompt": "hi" }`)

--- a/go-shell/sidecarclient/client.go
+++ b/go-shell/sidecarclient/client.go
@@ -1,0 +1,106 @@
+package sidecarclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
+	"github.com/spf13/viper"
+)
+
+type Client struct {
+	http    *retryablehttp.Client
+	httpURL string
+	wsURL   string
+	token   string
+}
+
+func New() *Client {
+	viper.AutomaticEnv()
+	c := &Client{
+		http:    retryablehttp.NewClient(),
+		httpURL: viper.GetString("SIDECAR_HTTP"),
+		wsURL:   viper.GetString("SIDECAR_WS"),
+		token:   viper.GetString("SIDECAR_TOKEN"),
+	}
+	if c.httpURL == "" {
+		c.httpURL = "http://localhost:8080"
+	}
+	if c.wsURL == "" {
+		c.wsURL = "ws://localhost:8080"
+	}
+	return c
+}
+
+type rpcRequest struct {
+	Method string      `json:"method"`
+	Params interface{} `json:"params"`
+}
+
+type rpcResponse struct {
+	Result json.RawMessage `json:"result"`
+	Error  string          `json:"error"`
+}
+
+func (c *Client) call(ctx context.Context, method string, params interface{}, result interface{}) error {
+	reqObj := rpcRequest{Method: method, Params: params}
+	body, err := json.Marshal(reqObj)
+	if err != nil {
+		return err
+	}
+	req, err := retryablehttp.NewRequest(http.MethodPost, c.httpURL+"/rpc", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	resp, err := c.http.Do(req.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var respObj rpcResponse
+	if err := json.NewDecoder(resp.Body).Decode(&respObj); err != nil {
+		return err
+	}
+	if respObj.Error != "" {
+		return fmt.Errorf("%s", respObj.Error)
+	}
+	if result != nil {
+		return json.Unmarshal(respObj.Result, result)
+	}
+	return nil
+}
+
+func (c *Client) Git(ctx context.Context, args []string) (string, error) {
+	var out string
+	err := c.call(ctx, "git", map[string]interface{}{"args": args}, &out)
+	return out, err
+}
+
+func (c *Client) RepoMap(ctx context.Context) (string, error) {
+	var out string
+	err := c.call(ctx, "repo_map", nil, &out)
+	return out, err
+}
+
+func (c *Client) LLM(ctx context.Context, prompt string) (string, error) {
+	var out string
+	err := c.call(ctx, "llm", map[string]string{"prompt": prompt}, &out)
+	return out, err
+}
+
+func (c *Client) DialWS(ctx context.Context, path string) (*websocket.Conn, *http.Response, error) {
+	url := c.wsURL + path
+	h := http.Header{}
+	if c.token != "" {
+		h.Set("Authorization", "Bearer "+c.token)
+	}
+	return websocket.DefaultDialer.DialContext(ctx, url, h)
+}


### PR DESCRIPTION
## Summary
- expose git, repo_map and llm functions through JSON-RPC in the Rust sidecar
- implement Go sidecar client with retryablehttp, gorilla/websocket and viper config
- document sidecar client usage and configuration

## Testing
- `cargo test`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689f0c698a648329bbb2cbe84a153769