### PR TITLE
feat: add Dart CLI scaffold with config and templating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ aider/_version.py
 .gitattributes
 tmp.benchmarks/
 .docker_bash_history
+# Dart
+**/.dart_tool/
+**/pubspec.lock

--- a/dart_cli/bin/dart_cli.dart
+++ b/dart_cli/bin/dart_cli.dart
@@ -1,0 +1,41 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:io/io.dart';
+
+import 'package:dart_cli/dart_cli.dart';
+
+Future<void> main(List<String> arguments) async {
+  final parser = ArgParser()
+    ..addFlag('help', abbr: 'h', negatable: false, help: 'Show help')
+    ..addOption('config', help: 'Configuration app name');
+
+  final argResults = parser.parse(arguments);
+
+  if (argResults['help'] as bool) {
+    stdout.writeln(parser.usage);
+    exit(ExitCode.success.code);
+  }
+
+  final configName = argResults['config'] as String? ?? 'dart_cli';
+  final config = await Config.load(configName);
+  stdout.writeln('Loaded config: ${config.data}');
+
+  final git = Git();
+  final gitResult = await git.run(['status', '--short']);
+  stdout.write(gitResult.stdout);
+
+  final client = HttpClient();
+  final response = await client.get<String>('https://example.com');
+  stdout.writeln('HTTP status: ${response.statusCode}');
+
+  final channel = connectWebSocket('wss://echo.websocket.events');
+  channel.sink.add('ping');
+  final wsMessage = await channel.stream.first;
+  stdout.writeln('WS event: $wsMessage');
+  await channel.sink.close();
+
+  final renderer = TemplateRenderer('Hello {{name}}');
+  stdout.writeln(renderer.render({'name': 'World'}));
+}

--- a/dart_cli/lib/dart_cli.dart
+++ b/dart_cli/lib/dart_cli.dart
@@ -1,0 +1,6 @@
+library dart_cli;
+
+export 'src/config.dart';
+export 'src/git.dart';
+export 'src/http_client.dart';
+export 'src/template.dart';

--- a/dart_cli/lib/src/config.dart
+++ b/dart_cli/lib/src/config.dart
@@ -1,0 +1,29 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:toml/toml.dart';
+import 'package:xdg_directories/xdg_directories.dart' as xdg;
+
+class Config {
+  final Map<String, dynamic> data;
+
+  Config(this.data);
+
+  static Future<Config> load(String appName) async {
+    final dir = xdg.configHome.path;
+    final jsonPath = p.join(dir, '$appName.json');
+    final tomlPath = p.join(dir, '$appName.toml');
+
+    if (await File(jsonPath).exists()) {
+      final content = await File(jsonPath).readAsString();
+      return Config(jsonDecode(content) as Map<String, dynamic>);
+    } else if (await File(tomlPath).exists()) {
+      final content = await File(tomlPath).readAsString();
+      final doc = TomlDocument.parse(content);
+      return Config(doc.toMap());
+    } else {
+      return Config({});
+    }
+  }
+}

--- a/dart_cli/lib/src/git.dart
+++ b/dart_cli/lib/src/git.dart
@@ -1,0 +1,10 @@
+import 'dart:io';
+
+import 'package:process_run/process_run.dart' as pr;
+
+class Git {
+  Future<ProcessResult> run(List<String> args, {String? workingDirectory}) {
+    return pr.runExecutableArguments('git', args,
+        workingDirectory: workingDirectory);
+  }
+}

--- a/dart_cli/lib/src/http_client.dart
+++ b/dart_cli/lib/src/http_client.dart
@@ -1,0 +1,12 @@
+import 'package:dio/dio.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+class HttpClient {
+  final Dio _dio = Dio();
+
+  Future<Response<T>> get<T>(String url) => _dio.get<T>(url);
+}
+
+WebSocketChannel connectWebSocket(String url) {
+  return WebSocketChannel.connect(Uri.parse(url));
+}

--- a/dart_cli/lib/src/template.dart
+++ b/dart_cli/lib/src/template.dart
@@ -1,0 +1,9 @@
+import 'package:mustache_template/mustache_template.dart';
+
+class TemplateRenderer {
+  final Template _template;
+
+  TemplateRenderer(String source) : _template = Template(source, lenient: true);
+
+  String render(Map<String, Object?> data) => _template.renderString(data);
+}

--- a/dart_cli/pubspec.yaml
+++ b/dart_cli/pubspec.yaml
@@ -1,0 +1,20 @@
+name: dart_cli
+description: Command-line interface for the Aider project.
+version: 0.1.0
+publish_to: none
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  args: ^2.4.2
+  io: ^1.0.4
+  process_run: ^0.12.4
+  dio: ^5.4.0
+  web_socket_channel: ^2.4.0
+  mustache_template: ^2.0.0
+  toml: ^0.15.0
+  xdg_directories: ^1.0.3
+  path: ^1.8.3
+
+dev_dependencies:
+  lints: ^5.0.0


### PR DESCRIPTION
## Summary
- scaffold `dart_cli` package using args/io/process_run
- add HTTP and WebSocket helpers with `dio` and `web_socket_channel`
- shell out to `git` for repo actions and load config from XDG paths
- render templates with Mustache and ignore Dart build artifacts

## Testing
- `dart pub get`
- `dart analyze`
- `dart format .`


------
https://chatgpt.com/codex/tasks/task_b_689fa7747bbc8329ae08f6bfb90d9c5c