### PR TITLE
Add unified build script, release packaging, and multi-lang CI

### DIFF
--- a/.github/workflows/multi-lang-ci.yml
+++ b/.github/workflows/multi-lang-ci.yml
@@ -1,0 +1,48 @@
+name: multi-lang-ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  rust:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: aider-cli
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+          profile: minimal
+      - run: cargo fmt -- --check
+      - run: cargo clippy -- -D warnings
+      - run: cargo test
+
+  go:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: go-shell
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - run: go vet ./...
+      - run: go test ./...
+
+  dart:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: dart analyze dart_cli
+      - run: dart test dart_cli
+      - run: flutter analyze flutter_app
+      - run: flutter test flutter_app

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+# Unified build orchestrator for aider-rs components
+.PHONY: build build-rust build-go build-flutter release clean
+
+build: build-rust build-go build-flutter
+
+build-rust:
+	cargo build --manifest-path aider-cli/Cargo.toml
+
+build-go:
+	mkdir -p build/go-shell
+	go build -o build/go-shell/go-shell ./go-shell
+
+build-flutter:
+	cd flutter_app && flutter build linux --release
+	cd flutter_app && flutter build macos --release
+	cd flutter_app && flutter build windows --release
+
+release: build
+	scripts/release.sh
+
+clean:
+	cargo clean --manifest-path aider-cli/Cargo.toml
+	go clean ./go-shell
+	cd flutter_app && flutter clean
+	rm -rf build dist

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")"/.. && pwd)"
+DIST="$ROOT/dist"
+rm -rf "$DIST"
+mkdir -p "$DIST"
+
+# Build Rust binaries for common targets
+for TARGET in x86_64-unknown-linux-gnu x86_64-pc-windows-gnu x86_64-apple-darwin; do
+  cargo build --manifest-path "$ROOT/aider-cli/Cargo.toml" --release --target "$TARGET"
+  BIN="$ROOT/aider-cli/target/$TARGET/release/aider-cli"
+  EXT=""
+  ARCHIVE="tar czf"
+  OUT="aider-cli-$TARGET"
+  if [[ "$TARGET" == *windows* ]]; then
+    EXT=".exe"
+    ARCHIVE="zip"
+  fi
+  mkdir -p "$DIST/$OUT"
+  cp "$BIN$EXT" "$DIST/$OUT/"
+  if [[ "$ARCHIVE" == zip ]]; then
+    (cd "$DIST/$OUT" && zip "../$OUT.zip" "aider-cli$EXT")
+  else
+    (cd "$DIST/$OUT" && tar czf "../$OUT.tar.gz" "aider-cli$EXT")
+  fi
+  rm -rf "$DIST/$OUT"
+done
+
+# Build Go binaries for common platforms
+for OS in linux windows darwin; do
+  EXT=""
+  OUT="go-shell-$OS"
+  if [[ "$OS" == windows ]]; then
+    EXT=".exe"
+  fi
+  mkdir -p "$DIST/$OUT"
+  GOOS=$OS GOARCH=amd64 go build -o "$DIST/$OUT/go-shell$EXT" "$ROOT/go-shell"
+  if [[ "$OS" == windows ]]; then
+    (cd "$DIST/$OUT" && zip "../$OUT.zip" "go-shell$EXT")
+  else
+    (cd "$DIST/$OUT" && tar czf "../$OUT.tar.gz" "go-shell$EXT")
+  fi
+  rm -rf "$DIST/$OUT"
+done
+
+# Build Flutter desktop bundles
+cd "$ROOT/flutter_app"
+for PLATFORM in linux windows macos; do
+  flutter build "$PLATFORM" --release
+  BDIR="build/$PLATFORM"
+  if [[ -d "$BDIR" ]]; then
+    if [[ "$PLATFORM" == windows ]]; then
+      (cd build && zip -r "$DIST/flutter_app-$PLATFORM.zip" "$PLATFORM")
+    else
+      (cd build && tar czf "$DIST/flutter_app-$PLATFORM.tar.gz" "$PLATFORM")
+    fi
+  fi
+done


### PR DESCRIPTION
## Summary
- add top-level Makefile orchestrating cargo, go build, and flutter build with release target
- implement cross-platform packaging script for Rust, Go, and Flutter bundles
- set up CI workflow running cargo fmt/clippy/test, go vet/test, and dart/flutter analyze/test

## Testing
- `cargo test` *(passes: 0 tests)*
- `go vet ./...` *(command hung: environment limitation)*
- `go test ./...` *(command hung: environment limitation)*
- `dart --version` *(command not found)*
- `flutter --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689fbc741a988329b97ef8b392dc9e32