### PR TITLE
feat: start python migration with rust git sidecar

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,3 +35,11 @@ sequenceDiagram
 
 The diagrams above depict how front-ends communicate with the Rust core through the sidecar and how data flows to shared resources.
 
+## Python to Rust migration
+
+Legacy Python utilities are being replaced with Rust implementations.  The first
+step introduces a small `git_sidecar` binary that mirrors portions of the
+`GitRepo` helper.  Python code can opt into the Rust path by setting
+`AIDER_USE_RUST=1`.  Progress and upcoming milestones are documented in
+[`MIGRATION.md`](MIGRATION.md).
+

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # Release history
 
+### Unreleased
+
+- Started Python to Rust migration. Added `git_sidecar` binary and optional
+  Python shim activated with `AIDER_USE_RUST`. Migration status tracked in
+  `MIGRATION.md`.
+
 ### Aider v0.86.0
 
 - Expanded GPT-5 model support across family variants and providers (OpenAI, Azure, OpenRouter), including dated and chat/mini/nano variants.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,20 @@
+# Migration Plan
+
+This document tracks the effort to retire Python helpers in favor of Rust equivalents.
+
+## Milestones
+
+| Milestone | Status | Notes |
+|-----------|--------|-------|
+| M1: Rust git helpers replace `GitRepo` | In progress | `git_sidecar` binary lists repository files |
+| M2: Rust repo map available, Python map deprecated | Pending | Rust `RepoMap` module exists |
+| M3: Command runner & other utilities ported | Pending | |
+| M4: Python layer removed | Pending | Final cleanup |
+
+## Compatibility
+
+Set the environment variable `AIDER_USE_RUST=1` to have existing Python modules
+invoke Rust sidecars such as `git_sidecar`.  When the variable is not set the
+original Python implementations act as a fallback during the transition.
+
+Progress on this migration should be updated here as milestones are completed.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ See the [installation instructions](https://aider.chat/docs/install.html) and [u
 - [Configuration Options](https://aider.chat/docs/config.html)
 - [Troubleshooting](https://aider.chat/docs/troubleshooting.html)
 - [FAQ](https://aider.chat/docs/faq.html)
+- [Migration Guide](MIGRATION.md)
 
 ### Community & Resources
 - [LLM Leaderboards](https://aider.chat/docs/leaderboards/)

--- a/aider-cli/src/bin/git_sidecar.rs
+++ b/aider-cli/src/bin/git_sidecar.rs
@@ -1,0 +1,20 @@
+use anyhow::Result;
+use ignore::WalkBuilder;
+
+fn main() -> Result<()> {
+    let root = std::env::current_dir()?;
+    for entry in WalkBuilder::new(&root)
+        .standard_filters(true)
+        .build()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|ft| ft.is_file()).unwrap_or(false))
+    {
+        let path = entry.into_path();
+        if let Ok(rel) = path.strip_prefix(&root) {
+            println!("{}", rel.display());
+        } else {
+            println!("{}", path.display());
+        }
+    }
+    Ok(())
+}

--- a/aider/repo.py
+++ b/aider/repo.py
@@ -1,5 +1,6 @@
 import contextlib
 import os
+import subprocess
 import time
 from pathlib import Path, PurePosixPath
 
@@ -431,6 +432,18 @@ class GitRepo:
         return diffs
 
     def get_tracked_files(self):
+        if os.getenv("AIDER_USE_RUST"):
+            try:
+                result = subprocess.run(
+                    ["git_sidecar"],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+                return result.stdout.splitlines()
+            except Exception:
+                pass
+
         if not self.repo:
             return []
 


### PR DESCRIPTION
## Summary
- add `git_sidecar` Rust binary to list repository files
- allow `GitRepo.get_tracked_files` to delegate to sidecar when `AIDER_USE_RUST=1`
- document migration milestones in new `MIGRATION.md` and update architecture docs

## Testing
- `cargo test --manifest-path aider-cli/Cargo.toml`
- `pytest -q` *(fails: No module named 'aider.resources')*

------
https://chatgpt.com/codex/tasks/task_b_68a007aef6e883299c19c1a0ed7bad80