### PR TITLE
Add Go installer for Rust, Go and Dart toolchains

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,16 @@ aider --model o3-mini --api-key openai=<key>
 
 See the [installation instructions](https://aider.chat/docs/install.html) and [usage documentation](https://aider.chat/docs/usage.html) for more details.
 
+### Language Toolchains
+
+This repository includes components written in Rust, Go and Dart. The helper script below installs the required toolchains on Windows and Linux environments:
+
+```
+go run scripts/install.go
+```
+
+The script downloads official installers for each language and avoids any Python-only dependencies.
+
 ## More Information
 
 ### Documentation

--- a/scripts/install.go
+++ b/scripts/install.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+func run(cmd string, args ...string) {
+	c := exec.Command(cmd, args...)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	if err := c.Run(); err != nil {
+		log.Fatalf("command failed: %s %v: %v", cmd, args, err)
+	}
+}
+
+func installLinux() {
+	fmt.Println("Installing Rust...")
+	run("sh", "-c", "curl https://sh.rustup.rs -sSf | sh -s -- -y")
+
+	fmt.Println("Installing Go...")
+	run("sh", "-c", "curl -L https://go.dev/dl/go1.22.4.linux-amd64.tar.gz -o /tmp/go.tar.gz && sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf /tmp/go.tar.gz")
+
+	fmt.Println("Installing Dart...")
+	run("sh", "-c", "curl -L https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/dartsdk-linux-x64-release.zip -o /tmp/dart.zip && sudo unzip -qo /tmp/dart.zip -d /usr/local && sudo mv /usr/local/dart-sdk /usr/local/dart")
+}
+
+func installWindows() {
+	fmt.Println("Installing Rust, Go and Dart with winget...")
+	run("cmd", "/C", "winget install --id Rustlang.Rustup -e --silent")
+	run("cmd", "/C", "winget install --id GoLang.Go -e --silent")
+	run("cmd", "/C", "winget install --id Google.Dart -e --silent")
+}
+
+func main() {
+	switch runtime.GOOS {
+	case "linux":
+		installLinux()
+	case "windows":
+		installWindows()
+	default:
+		fmt.Println("Unsupported OS:", runtime.GOOS)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go script that installs Rust, Go and Dart for Windows and Linux
- document running the installer in the README

## Testing
- `go build scripts/install.go`
- `go vet scripts/install.go`


------
https://chatgpt.com/codex/tasks/task_b_68a0fb75ed5c83299289a88569d3ca34