### PR TITLE
feat: add command rpc and clients

### DIFF
--- a/aider-cli/src/analytics.rs
+++ b/aider-cli/src/analytics.rs
@@ -28,4 +28,3 @@ impl Analytics {
         }
     }
 }
-

--- a/aider-cli/src/args.rs
+++ b/aider-cli/src/args.rs
@@ -18,4 +18,3 @@ pub struct CliArgs {
     #[arg(long)]
     pub save_config: bool,
 }
-

--- a/aider-cli/src/history.rs
+++ b/aider-cli/src/history.rs
@@ -28,4 +28,3 @@ impl History {
         }
     }
 }
-

--- a/aider-cli/src/main.rs
+++ b/aider-cli/src/main.rs
@@ -54,7 +54,7 @@ fn main() -> Result<()> {
     ctx.insert("name", "world");
     let rendered = prompts.render_str("Hello {{name}}!", &ctx)?;
     if args.verbose {
-        println!("{}", rendered);
+        println!("{rendered}");
     }
 
     // Demonstrate loading resources in multiple formats.

--- a/aider-cli/src/prompts.rs
+++ b/aider-cli/src/prompts.rs
@@ -2,20 +2,18 @@ use anyhow::Result;
 use tera::{Context, Tera};
 
 /// Template handling using `tera`, replacing the Python `prompts.py` module.
+#[derive(Default)]
 pub struct Prompts {
     tera: Tera,
 }
 
-impl Default for Prompts {
-    fn default() -> Self {
-        Self { tera: Tera::default() }
-    }
-}
-
 impl Prompts {
     /// Load templates from the provided glob pattern.
+    #[allow(dead_code)]
     pub fn new(glob: &str) -> Result<Self> {
-        Ok(Self { tera: Tera::new(glob)? })
+        Ok(Self {
+            tera: Tera::new(glob)?,
+        })
     }
 
     /// Render a template string with the supplied context.
@@ -23,4 +21,3 @@ impl Prompts {
         Ok(self.tera.render_str(template, ctx)?)
     }
 }
-

--- a/aider-cli/src/repo.rs
+++ b/aider-cli/src/repo.rs
@@ -26,4 +26,3 @@ impl Repo {
             .collect()
     }
 }
-

--- a/aider-cli/src/repomap.rs
+++ b/aider-cli/src/repomap.rs
@@ -8,6 +8,7 @@ use tree_sitter_highlight::{HighlightConfiguration, Highlighter};
 /// Port of the Python `repomap.py` using `tree-sitter`.
 pub struct RepoMap {
     parser: Parser,
+    #[allow(dead_code)]
     highlight: HighlightConfiguration,
 }
 
@@ -18,12 +19,8 @@ impl RepoMap {
         let mut parser = Parser::new();
         parser.set_language(language)?;
 
-        let highlight = HighlightConfiguration::new(
-            language,
-            tree_sitter_python::HIGHLIGHT_QUERY,
-            "",
-            "",
-        )?;
+        let highlight =
+            HighlightConfiguration::new(language, tree_sitter_python::HIGHLIGHT_QUERY, "", "")?;
 
         Ok(Self { parser, highlight })
     }
@@ -37,19 +34,16 @@ impl RepoMap {
     }
 
     /// Highlight a string using the configured grammar.
+    #[allow(dead_code)]
     pub fn highlight(&self, source: &str) -> Result<Vec<String>> {
         let mut highlighter = Highlighter::new();
         let mut ranges = Vec::new();
         let bytes = source.as_bytes();
         for event in highlighter.highlight(&self.highlight, bytes, None, |_| None)? {
-            match event? {
-                tree_sitter_highlight::HighlightEvent::Source { start, end } => {
-                    ranges.push(String::from_utf8_lossy(&bytes[start..end]).into_owned());
-                }
-                _ => {}
+            if let tree_sitter_highlight::HighlightEvent::Source { start, end } = event? {
+                ranges.push(String::from_utf8_lossy(&bytes[start..end]).into_owned());
             }
         }
         Ok(ranges)
     }
 }
-

--- a/aider-cli/src/resources.rs
+++ b/aider-cli/src/resources.rs
@@ -19,6 +19,7 @@ pub fn load_yaml<P: AsRef<Path>>(path: P) -> Result<YamlValue> {
 }
 
 /// Load a TOML resource from disk.
+#[allow(dead_code)]
 pub fn load_toml<P: AsRef<Path>>(path: P) -> Result<TomlValue> {
     let data = fs::read_to_string(path)?;
     Ok(toml::from_str(&data)?)

--- a/aider-cli/src/settings.rs
+++ b/aider-cli/src/settings.rs
@@ -6,16 +6,10 @@ use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 
 /// Persistent user settings stored as TOML or YAML.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Settings {
     /// Mirror of the `--verbose` flag.
     pub verbose: bool,
-}
-
-impl Default for Settings {
-    fn default() -> Self {
-        Self { verbose: false }
-    }
 }
 
 impl Settings {
@@ -67,7 +61,5 @@ impl Settings {
 }
 
 fn default_config_path() -> Option<PathBuf> {
-    ProjectDirs::from("com", "aider", "aider-cli")
-        .map(|dir| dir.config_dir().join("settings.toml"))
+    ProjectDirs::from("com", "aider", "aider-cli").map(|dir| dir.config_dir().join("settings.toml"))
 }
-

--- a/aider-cli/src/watch.rs
+++ b/aider-cli/src/watch.rs
@@ -8,17 +8,23 @@ use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
 /// Handle for a running watcher returning filtered events.
 pub struct WatcherHandle {
     _watcher: RecommendedWatcher,
+    #[allow(dead_code)]
     pub rx: Receiver<Result<Event, notify::Error>>,
+    #[allow(dead_code)]
     gitignore: Gitignore,
 }
 
 impl WatcherHandle {
     /// Wait for the next path change that isn't ignored.
+    #[allow(dead_code)]
     pub fn next_path(&self) -> Option<PathBuf> {
         while let Ok(event) = self.rx.recv() {
             if let Ok(event) = event {
                 for path in event.paths {
-                    if !self.gitignore.matched_path_or_any_parents(&path, path.is_dir()).is_ignore()
+                    if !self
+                        .gitignore
+                        .matched_path_or_any_parents(&path, path.is_dir())
+                        .is_ignore()
                     {
                         return Some(path);
                     }
@@ -45,4 +51,3 @@ pub fn watch(path: &Path) -> Result<WatcherHandle> {
         gitignore,
     })
 }
-

--- a/aider-core/Cargo.lock
+++ b/aider-core/Cargo.lock
@@ -288,6 +288,7 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http 1.3.1",
@@ -306,8 +307,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -456,6 +459,12 @@ name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -777,6 +786,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "deranged"
@@ -3603,6 +3618,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3638,6 +3664,8 @@ dependencies = [
  "aider-analytics",
  "aider-core",
  "axum",
+ "crossterm",
+ "futures-util",
  "serde",
  "serde_json",
  "tokio",
@@ -3995,6 +4023,7 @@ dependencies = [
  "libc",
  "mio 1.0.4",
  "pin-project-lite",
+ "signal-hook-registry",
  "slab",
  "socket2 0.6.0",
  "tokio-macros",
@@ -4030,6 +4059,18 @@ checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -4155,6 +4196,24 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
 
 [[package]]
 name = "typenum"
@@ -4293,6 +4352,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/aider-core/core/src/lib.rs
+++ b/aider-core/core/src/lib.rs
@@ -1,4 +1,3 @@
-use reqwest;
 use std::process::Command;
 use thiserror::Error;
 use tracing::info;

--- a/aider-core/sidecar/Cargo.toml
+++ b/aider-core/sidecar/Cargo.toml
@@ -4,9 +4,11 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-axum = "0.7"
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+axum = { version = "0.7", features = ["ws"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "io-util"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 aider-core = { path = "../core" }
 aider-analytics = { path = "../analytics" }
+crossterm = { version = "0.27", optional = false }
+futures-util = { version = "0.3", features = ["sink"] }

--- a/aider-core/sidecar/src/main.rs
+++ b/aider-core/sidecar/src/main.rs
@@ -1,14 +1,24 @@
 use aider_analytics::Analytics;
 use axum::{
     Json, Router,
-    extract::State,
+    extract::{
+        State,
+        ws::{Message, WebSocket, WebSocketUpgrade},
+    },
     http::{HeaderMap, StatusCode},
     routing::{get, post},
 };
+#[cfg(unix)]
+use crossterm::tty::IsTty;
+use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{env, net::SocketAddr};
-use tokio::net::TcpListener;
+use tokio::{
+    io::{AsyncBufReadExt, BufReader},
+    net::TcpListener,
+    process::Command,
+};
 
 #[derive(Clone)]
 struct AppState {
@@ -126,6 +136,80 @@ async fn rpc_handler(
     (StatusCode::OK, Json(resp))
 }
 
+async fn command_ws(ws: WebSocketUpgrade) -> impl axum::response::IntoResponse {
+    ws.on_upgrade(handle_command)
+}
+
+async fn handle_command(socket: WebSocket) {
+    let (mut sender, mut receiver) = socket.split();
+    if let Some(Ok(Message::Text(txt))) = receiver.next().await {
+        #[derive(Deserialize)]
+        struct CmdReq {
+            cmd: String,
+            args: Vec<String>,
+        }
+        let req: CmdReq = serde_json::from_str(&txt).unwrap_or(CmdReq {
+            cmd: String::new(),
+            args: vec![],
+        });
+
+        #[cfg(unix)]
+        let mut cmd = {
+            let _ = std::io::stdout().is_tty();
+            let mut c = Command::new(&req.cmd);
+            c.args(&req.args);
+            c
+        };
+
+        #[cfg(windows)]
+        let mut cmd = {
+            use std::ffi::OsString;
+            let mut c = if req.cmd.ends_with(".ps1") {
+                let mut p = Command::new("powershell");
+                p.arg("-File").arg(&req.cmd);
+                p
+            } else {
+                let mut p = Command::new("cmd.exe");
+                p.arg("/C").arg(&req.cmd);
+                p
+            };
+            c
+        };
+
+        cmd.stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+
+        match cmd.spawn() {
+            Ok(mut child) => {
+                let mut stdout = BufReader::new(child.stdout.take().unwrap()).lines();
+                let mut stderr = BufReader::new(child.stderr.take().unwrap()).lines();
+                loop {
+                    tokio::select! {
+                        Ok(Some(line)) = stdout.next_line() => {
+                            let msg = serde_json::json!({"type":"stdout","data":line});
+                            if sender.send(Message::Text(msg.to_string())).await.is_err() { break; }
+                        }
+                        Ok(Some(line)) = stderr.next_line() => {
+                            let msg = serde_json::json!({"type":"stderr","data":line});
+                            if sender.send(Message::Text(msg.to_string())).await.is_err() { break; }
+                        }
+                        status = child.wait() => {
+                            let code = status.map(|s| s.code().unwrap_or(-1)).unwrap_or(-1);
+                            let msg = serde_json::json!({"type":"exit","code":code});
+                            let _ = sender.send(Message::Text(msg.to_string())).await;
+                            break;
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                let msg = serde_json::json!({"type":"error","message":e.to_string()});
+                let _ = sender.send(Message::Text(msg.to_string())).await;
+            }
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() {
     let token = env::var("SIDECAR_TOKEN").ok();
@@ -137,6 +221,7 @@ async fn main() {
     let app = Router::new()
         .route("/ping", get(ping))
         .route("/rpc", post(rpc_handler))
+        .route("/command", get(command_ws))
         .with_state(state);
     let addr = SocketAddr::from(([127, 0, 0, 1], 8080));
     println!("listening on {addr}");

--- a/aider-core/sidecar/src/main.rs
+++ b/aider-core/sidecar/src/main.rs
@@ -99,7 +99,7 @@ async fn rpc_handler(
             let params: ChatParams =
                 serde_json::from_value(req.params).unwrap_or(ChatParams { messages: vec![] });
             match aider_core::chat::chat(&params.messages).await {
-                Ok(ans) => RpcResponse::result(Value::String(ans)),
+                Ok(answer) => RpcResponse::result(Value::String(answer)),
                 Err(e) => RpcResponse::error(e.to_string()),
             }
         }

--- a/dart_cli/bin/dart_cli.dart
+++ b/dart_cli/bin/dart_cli.dart
@@ -24,7 +24,7 @@ Future<void> main(List<String> arguments) async {
 
   final git = Git();
   final gitResult = await git.run(['status', '--short']);
-  stdout.write(gitResult.stdout);
+  stdout.write(gitResult);
 
   final client = HttpClient();
   final response = await client.get<String>('https://example.com');

--- a/dart_cli/lib/src/git.dart
+++ b/dart_cli/lib/src/git.dart
@@ -1,10 +1,14 @@
-import 'dart:io';
-
-import 'package:process_run/process_run.dart' as pr;
+import 'dart:async';
+import 'package:dart_cli/src/sidecar.dart' as sidecar;
 
 class Git {
-  Future<ProcessResult> run(List<String> args, {String? workingDirectory}) {
-    return pr.runExecutableArguments('git', args,
-        workingDirectory: workingDirectory);
+  Future<String> run(List<String> args) async {
+    final buffer = StringBuffer();
+    final code =
+        await sidecar.command('git', args, (type, data) => buffer.write(data));
+    if (code != 0) {
+      throw Exception('git exited with code $code');
+    }
+    return buffer.toString();
   }
 }

--- a/dart_cli/lib/src/git.dart
+++ b/dart_cli/lib/src/git.dart
@@ -4,8 +4,11 @@ import 'package:dart_cli/src/sidecar.dart' as sidecar;
 class Git {
   Future<String> run(List<String> args) async {
     final buffer = StringBuffer();
-    final code =
-        await sidecar.command('git', args, (type, data) => buffer.write(data));
+    final code = await sidecar.command(
+      'git',
+      args,
+      (type, data) => buffer.write(data),
+    );
     if (code != 0) {
       throw Exception('git exited with code $code');
     }

--- a/dart_cli/lib/src/resources.dart
+++ b/dart_cli/lib/src/resources.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:toml/toml.dart';
-import 'package:yaml/yaml.dart';
+import 'package:yaml/yaml.dart' as yaml;
 
 Future<Map<String, dynamic>> loadJson(String path) async {
   final text = await File(path).readAsString();
@@ -11,7 +11,7 @@ Future<Map<String, dynamic>> loadJson(String path) async {
 
 Future<Map<String, dynamic>> loadYaml(String path) async {
   final text = await File(path).readAsString();
-  final doc = loadYaml(text);
+  final doc = yaml.loadYaml(text);
   return Map<String, dynamic>.from(doc as Map);
 }
 

--- a/dart_cli/lib/src/sidecar.dart
+++ b/dart_cli/lib/src/sidecar.dart
@@ -3,16 +3,18 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:dio/dio.dart';
 
-final String _baseUrl = Platform.environment['SIDECAR_HTTP'] ?? 'http://localhost:8080';
-final String _wsBase = Platform.environment['SIDECAR_WS'] ?? 'ws://localhost:8080';
+final String _baseUrl =
+    Platform.environment['SIDECAR_HTTP'] ?? 'http://localhost:8080';
+final String _wsBase =
+    Platform.environment['SIDECAR_WS'] ?? 'ws://localhost:8080';
 final String _token = Platform.environment['SIDECAR_TOKEN'] ?? '';
 final Dio _dio = Dio(BaseOptions(baseUrl: _baseUrl));
 
 Future<Response<dynamic>> _rpc(String method, Map<String, dynamic>? params) {
   final data = {'method': method, 'params': params ?? {}};
-  final options = Options(headers: {
-    if (_token.isNotEmpty) 'Authorization': 'Bearer $_token',
-  });
+  final options = Options(
+    headers: {if (_token.isNotEmpty) 'Authorization': 'Bearer $_token'},
+  );
   return _dio.post('/rpc', data: data, options: options);
 }
 
@@ -30,12 +32,13 @@ Future<String> llmChat(List<Map<String, String>> messages) async {
   return body['result'] as String;
 }
 
-Future<int> command(String cmd, List<String> args,
-    void Function(String type, String data) onOutput) async {
+Future<int> command(
+  String cmd,
+  List<String> args,
+  void Function(String type, String data) onOutput,
+) async {
   final uri = Uri.parse('$_wsBase/command');
-  final headers = {
-    if (_token.isNotEmpty) 'Authorization': 'Bearer $_token',
-  };
+  final headers = {if (_token.isNotEmpty) 'Authorization': 'Bearer $_token'};
   final ws = await WebSocket.connect(uri.toString(), headers: headers);
   ws.add(jsonEncode({'cmd': cmd, 'args': args}));
   final completer = Completer<int>();

--- a/dart_cli/lib/src/sidecar.dart
+++ b/dart_cli/lib/src/sidecar.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'package:dio/dio.dart';
 
 final String _baseUrl = Platform.environment['SIDECAR_HTTP'] ?? 'http://localhost:8080';
+final String _wsBase = Platform.environment['SIDECAR_WS'] ?? 'ws://localhost:8080';
 final String _token = Platform.environment['SIDECAR_TOKEN'] ?? '';
 final Dio _dio = Dio(BaseOptions(baseUrl: _baseUrl));
 
@@ -25,4 +28,26 @@ Future<String> llmChat(List<Map<String, String>> messages) async {
   final body = resp.data as Map<String, dynamic>;
   if (body['error'] != null) throw Exception(body['error']);
   return body['result'] as String;
+}
+
+Future<int> command(String cmd, List<String> args,
+    void Function(String type, String data) onOutput) async {
+  final uri = Uri.parse('$_wsBase/command');
+  final headers = {
+    if (_token.isNotEmpty) 'Authorization': 'Bearer $_token',
+  };
+  final ws = await WebSocket.connect(uri.toString(), headers: headers);
+  ws.add(jsonEncode({'cmd': cmd, 'args': args}));
+  final completer = Completer<int>();
+  ws.listen((event) {
+    final msg = jsonDecode(event as String) as Map<String, dynamic>;
+    final type = msg['type'] as String;
+    if (type == 'exit') {
+      completer.complete(msg['code'] as int);
+      ws.close();
+    } else if (type == 'stdout' || type == 'stderr') {
+      onOutput(type, msg['data'] as String);
+    }
+  });
+  return completer.future;
 }

--- a/dart_cli/pubspec.yaml
+++ b/dart_cli/pubspec.yaml
@@ -8,7 +8,6 @@ environment:
 dependencies:
   args: ^2.4.2
   io: ^1.0.4
-  process_run: ^0.12.4
   dio: ^5.4.0
   web_socket_channel: ^2.4.0
   mustache_template: ^2.0.0

--- a/go-shell/cmd/root.go
+++ b/go-shell/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aider-rs/go-shell/internal/resources"
 	"github.com/aider-rs/go-shell/internal/sidecar"
 	"github.com/aider-rs/go-shell/internal/tui"
+	sc "github.com/aider-rs/go-shell/sidecarclient"
 )
 
 var rootCmd = &cobra.Command{
@@ -36,6 +37,20 @@ var rootCmd = &cobra.Command{
 			logger.Info("sidecar", zap.String("msg", msg))
 		} else {
 			logger.Warn("sidecar ping failed", zap.Error(err))
+		}
+
+		client := sc.New()
+		outCh, codeCh, err := client.Command(ctx, "git", []string{"--version"})
+		if err == nil {
+			go func() {
+				for line := range outCh {
+					logger.Info("cmd", zap.String("out", line))
+				}
+			}()
+			exitCode := <-codeCh
+			logger.Info("cmd exit", zap.Int("code", exitCode))
+		} else {
+			logger.Warn("command failed", zap.Error(err))
 		}
 
 		if err := tui.New().Start(); err != nil {


### PR DESCRIPTION
## Summary
- add websocket-based `command` RPC with streaming output
- expose command runner in Go and Dart clients
- clean up Dart Git helper to use RPC

## Testing
- `cargo test` (sidecar)
- `go test ./...`
- `dart format dart_cli/lib/src/sidecar.dart dart_cli/lib/src/git.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0ff6a318c8329848da82caf7ff0a7