### PR TITLE
feat: add Rust search-replace coder and Tera templates

### DIFF
--- a/aider-cli/src/main.rs
+++ b/aider-cli/src/main.rs
@@ -48,11 +48,11 @@ fn main() -> Result<()> {
     let mut history = history::History::new(data_dir.join("history.yaml"));
     history.add("run".to_string());
 
-    // Demonstrate prompt template rendering.
-    let mut prompts = prompts::Prompts::default();
+    // Demonstrate prompt template rendering from resources/templates.
+    let prompts = prompts::Prompts::new()?;
     let mut ctx = tera::Context::new();
     ctx.insert("name", "world");
-    let rendered = prompts.render_str("Hello {{name}}!", &ctx)?;
+    let rendered = prompts.render("welcome.tera", &ctx)?;
     if args.verbose {
         println!("{rendered}");
     }
@@ -60,7 +60,6 @@ fn main() -> Result<()> {
     // Demonstrate loading resources in multiple formats.
     let _meta = resources::load_json("resources/model-metadata.json")?;
     let _settings = resources::load_yaml("resources/model-settings.yml")?;
-    let _prompt = resources::load_prompt("resources/prompts/welcome.mustache")?;
 
     // Start file watching in the background.
     let _watcher = watch::watch(&std::env::current_dir()?)?;

--- a/aider-cli/src/prompts.rs
+++ b/aider-cli/src/prompts.rs
@@ -2,21 +2,24 @@ use anyhow::Result;
 use tera::{Context, Tera};
 
 /// Template handling using `tera`, replacing the Python `prompts.py` module.
-#[derive(Default)]
 pub struct Prompts {
     tera: Tera,
 }
 
 impl Prompts {
-    /// Load templates from the provided glob pattern.
-    #[allow(dead_code)]
-    pub fn new(glob: &str) -> Result<Self> {
+    /// Load templates from the `resources/templates` directory.
+    pub fn new() -> Result<Self> {
         Ok(Self {
-            tera: Tera::new(glob)?,
+            tera: Tera::new("resources/templates/**/*")?,
         })
     }
 
-    /// Render a template string with the supplied context.
+    /// Render a named template file with the supplied context.
+    pub fn render(&self, name: &str, ctx: &Context) -> Result<String> {
+        Ok(self.tera.render(name, ctx)?)
+    }
+
+    /// Render a raw template string with the supplied context.
     pub fn render_str(&mut self, template: &str, ctx: &Context) -> Result<String> {
         Ok(self.tera.render_str(template, ctx)?)
     }

--- a/aider-cli/src/resources.rs
+++ b/aider-cli/src/resources.rs
@@ -25,7 +25,3 @@ pub fn load_toml<P: AsRef<Path>>(path: P) -> Result<TomlValue> {
     Ok(toml::from_str(&data)?)
 }
 
-/// Load a plain text prompt template.
-pub fn load_prompt<P: AsRef<Path>>(path: P) -> Result<String> {
-    Ok(fs::read_to_string(path)?)
-}

--- a/aider-core/core/src/coders/mod.rs
+++ b/aider-core/core/src/coders/mod.rs
@@ -1,0 +1,9 @@
+pub mod search_replace;
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum CoderError {
+    #[error("search text not found")]
+    NotFound,
+}

--- a/aider-core/core/src/coders/search_replace.rs
+++ b/aider-core/core/src/coders/search_replace.rs
@@ -1,0 +1,10 @@
+use super::CoderError;
+
+/// Perform a simple search and replace on the provided content.
+/// Returns an error if the search string is not found.
+pub fn search_replace(content: &str, search: &str, replace: &str) -> Result<String, CoderError> {
+    if !content.contains(search) {
+        return Err(CoderError::NotFound);
+    }
+    Ok(content.replace(search, replace))
+}

--- a/aider-core/core/src/lib.rs
+++ b/aider-core/core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod chat;
 pub mod models;
 pub mod scrape;
 pub mod voice;
+pub mod coders;
 
 #[derive(Error, Debug)]
 pub enum CoreError {

--- a/aider-core/sidecar/src/main.rs
+++ b/aider-core/sidecar/src/main.rs
@@ -1,4 +1,5 @@
 use aider_analytics::Analytics;
+use aider_core::coders::search_replace::search_replace;
 use axum::{
     Json, Router,
     extract::{
@@ -120,6 +121,24 @@ async fn rpc_handler(
                 serde_json::from_value(req.params).unwrap_or(ScrapeParams { url: String::new() });
             match aider_core::scrape::scrape_url(&params.url).await {
                 Ok(md) => RpcResponse::result(Value::String(md)),
+                Err(e) => RpcResponse::error(e.to_string()),
+            }
+        }
+        "coder.search_replace" => {
+            #[derive(Deserialize)]
+            struct Params {
+                content: String,
+                search: String,
+                replace: String,
+            }
+            let params: Params =
+                serde_json::from_value(req.params).unwrap_or(Params {
+                    content: String::new(),
+                    search: String::new(),
+                    replace: String::new(),
+                });
+            match search_replace(&params.content, &params.search, &params.replace) {
+                Ok(out) => RpcResponse::result(Value::String(out)),
                 Err(e) => RpcResponse::error(e.to_string()),
             }
         }

--- a/dart_cli/bin/dart_cli.dart
+++ b/dart_cli/bin/dart_cli.dart
@@ -42,5 +42,8 @@ Future<void> main(List<String> arguments) async {
   // Demonstrate loading shared resources.
   await loadJson('../resources/model-metadata.json');
   await loadYaml('../resources/model-settings.yml');
-  await loadPrompt('../resources/prompts/welcome.mustache');
+  await loadTemplate('../resources/templates/welcome.tera');
+  final replaced =
+      await coderSearchReplace('hello world', 'world', 'dart');
+  stdout.writeln('SearchReplace: $replaced');
 }

--- a/dart_cli/lib/src/resources.dart
+++ b/dart_cli/lib/src/resources.dart
@@ -21,6 +21,6 @@ Future<Map<String, dynamic>> loadToml(String path) async {
   return doc.toMap();
 }
 
-Future<String> loadPrompt(String path) async {
+Future<String> loadTemplate(String path) async {
   return File(path).readAsString();
 }

--- a/dart_cli/lib/src/sidecar.dart
+++ b/dart_cli/lib/src/sidecar.dart
@@ -39,6 +39,15 @@ Future<String> scrapeUrl(String url) async {
   return body['result'] as String;
 }
 
+Future<String> coderSearchReplace(
+    String content, String search, String replace) async {
+  final resp = await _rpc('coder.search_replace',
+      {'content': content, 'search': search, 'replace': replace});
+  final body = resp.data as Map<String, dynamic>;
+  if (body['error'] != null) throw Exception(body['error']);
+  return body['result'] as String;
+}
+
 Future<int> command(
   String cmd,
   List<String> args,

--- a/go-shell/sidecarclient/client.go
+++ b/go-shell/sidecarclient/client.go
@@ -120,6 +120,13 @@ func (c *Client) ScrapeURL(ctx context.Context, url string) (string, error) {
         return out, err
 }
 
+func (c *Client) CoderSearchReplace(ctx context.Context, content, search, replace string) (string, error) {
+        var out string
+        params := map[string]interface{}{"content": content, "search": search, "replace": replace}
+        err := c.call(ctx, "coder.search_replace", params, &out)
+        return out, err
+}
+
 func (c *Client) VoiceRecord(ctx context.Context) (string, error) {
         var out string
         err := c.call(ctx, "voice.record", nil, &out)

--- a/resources/prompts/welcome.mustache
+++ b/resources/prompts/welcome.mustache
@@ -1,1 +1,0 @@
-Hello, {{name}}!

--- a/resources/templates/welcome.tera
+++ b/resources/templates/welcome.tera
@@ -1,0 +1,1 @@
+Hello, {{ name }}!


### PR DESCRIPTION
## Summary
- move prompt templates to `resources/templates` and render with Tera
- add simple Rust `search_replace` coder and expose via sidecar RPC
- provide Go and Dart client wrappers for the new coder

## Testing
- `cargo test` in `aider-core`
- `cargo test` in `aider-cli`
- `go test ./...` in `go-shell`
- :warning: `dart pub get` (dart: command not found)


------
https://chatgpt.com/codex/tasks/task_b_68a13907b37c8329a4260e818d66fbca