### PR TITLE
feat: add unified Rust, Go, and Flutter CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'v*'
+  pull_request:
+
+jobs:
+  rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+          profile: minimal
+          override: true
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-targets -- -D warnings
+      - run: cargo test --all
+
+  go:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        module: [go-shell, go_cli]
+    defaults:
+      run:
+        working-directory: ${{ matrix.module }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+          cache-dependency-path: ${{ matrix.module }}/go.sum
+      - run: go fmt ./...
+      - run: go vet ./...
+      - run: go test ./...
+
+  flutter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - uses: actions/cache@v3
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock', '**/pubspec.yaml') }}
+      - name: Dart CLI
+        working-directory: dart_cli
+        run: |
+          dart pub get
+          dart format --output=none --set-exit-if-changed .
+          dart analyze
+          dart test
+      - name: Flutter App
+        working-directory: flutter_app
+        run: |
+          flutter pub get
+          flutter format --output=none --set-exit-if-changed .
+          flutter analyze
+          flutter test
+
+  release:
+    needs: [rust, go, flutter]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --release --locked -p aider-cli
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: aider-cli/target/release/aider-cli


### PR DESCRIPTION
## Summary
- add CI workflow that builds Rust, Go 1.22, and Flutter projects
- cache cargo, go modules, and pub packages; run fmt, lint, and tests
- publish Rust binaries on tagged releases

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_b_68a28b0437f0832992974eab943409ed