### PR TITLE
feat: add CLI parsing and stub session dispatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
 reqwest = { version = "0.11", features = ["json", "stream"] }
 tokio = { version = "1", features = ["full"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 git2 = "0.18"
 ignore = "0.4"
 notify = "6"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,12 +1,47 @@
 use anyhow::Result;
 use clap::Parser;
 
-#[derive(Parser)]
-struct Args {}
+/// Command line interface for the aider core library.
+///
+/// The real application will provide an interactive coding session. For now
+/// we parse a few options and forward them to a stub session so that the
+/// binary can be exercised.
+#[derive(Parser, Debug)]
+#[command(
+    name = "aider",
+    version,
+    about = "AI pair programmer",
+    after_help = "EXAMPLES:\n  aider --model gpt-4\n  aider --dry-run \"Refactor main.rs\""
+)]
+struct Args {
+    /// LLM model to use
+    #[arg(long, default_value = "gpt-4")]
+    model: String,
+
+    /// OpenAI API key (also read from OPENAI_API_KEY env variable)
+    #[arg(long, env = "OPENAI_API_KEY")]
+    openai_api_key: Option<String>,
+
+    /// Don't write any changes, just show what would happen
+    #[arg(long)]
+    dry_run: bool,
+
+    /// Optional prompt to start the session
+    #[arg()]
+    prompt: Vec<String>,
+}
 
 fn main() -> Result<()> {
-    let _ = Args::parse();
+    let args = Args::parse();
     aider_core::init_tracing()?;
-    println!("aider cli placeholder");
+    let prompt = if args.prompt.is_empty() {
+        None
+    } else {
+        Some(args.prompt.join(" "))
+    };
+
+    let mut session =
+        aider_core::Session::new(args.model, prompt, args.openai_api_key, args.dry_run);
+    session.run()?;
     Ok(())
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2,6 +2,9 @@ use anyhow::Result;
 use tracing::info;
 use tracing_subscriber::FmtSubscriber;
 
+pub mod session;
+pub use session::Session;
+
 pub fn init_tracing() -> Result<()> {
     let subscriber = FmtSubscriber::new();
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -1,0 +1,49 @@
+use anyhow::Result;
+
+/// Placeholder for the core interactive session.
+///
+/// The real implementation will manage conversations with an LLM and
+/// apply edits to the user's repository. For now we just record the
+/// settings and emit helpful messages so the CLI can be exercised
+/// without crashing.
+#[derive(Debug)]
+pub struct Session {
+    model: String,
+    prompt: Option<String>,
+    api_key: Option<String>,
+    dry_run: bool,
+}
+
+impl Session {
+    /// Create a new session with the chosen options.
+    pub fn new(
+        model: String,
+        prompt: Option<String>,
+        api_key: Option<String>,
+        dry_run: bool,
+    ) -> Self {
+        Self {
+            model,
+            prompt,
+            api_key,
+            dry_run,
+        }
+    }
+
+    /// Run the session. Currently this only prints stub messages.
+    pub fn run(&mut self) -> Result<()> {
+        println!("Starting aider session with model: {}", self.model);
+        if let Some(ref msg) = self.prompt {
+            println!("Initial prompt: {msg}");
+        }
+        match self.api_key {
+            Some(_) => println!("API key support is not implemented; key ignored."),
+            None => println!("No API key provided; network features are disabled."),
+        }
+        if self.dry_run {
+            println!("Dry-run mode selected. No changes will be written.");
+        }
+        println!("Interactive editing is not implemented yet.");
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- add Clap-based argument parsing for the `aider` CLI
- wire CLI options into a stub `Session` in `aider_core`
- provide helpful messages for unimplemented features

## Testing
- `cargo test`
- `cargo run -p aider-cli -- --help`
- `cargo run -p aider-cli -- --dry-run`


------
https://chatgpt.com/codex/tasks/task_b_68a2943408148329898bc8c66cce0af6