### PR TITLE
feat: add echo session loop with cancel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,7 @@ dependencies = [
  "aider-core",
  "anyhow",
  "clap",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 aider-core = { path = "../core" }
 anyhow = { workspace = true }
 clap = { workspace = true }
+tokio = { workspace = true }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -31,7 +31,8 @@ struct Args {
     prompt: Vec<String>,
 }
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     let args = Args::parse();
     aider_core::init_tracing()?;
     let prompt = if args.prompt.is_empty() {
@@ -42,6 +43,6 @@ fn main() -> Result<()> {
 
     let mut session =
         aider_core::Session::new(args.model, prompt, args.openai_api_key, args.dry_run);
-    session.run()?;
+    session.run().await?;
     Ok(())
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2,7 +2,9 @@ use anyhow::Result;
 use tracing::info;
 use tracing_subscriber::FmtSubscriber;
 
+pub mod model;
 pub mod session;
+pub use model::{EchoModel, Model};
 pub use session::Session;
 
 pub fn init_tracing() -> Result<()> {

--- a/crates/core/src/model.rs
+++ b/crates/core/src/model.rs
@@ -1,0 +1,45 @@
+use tokio::sync::mpsc;
+use tokio::time::{sleep, Duration};
+use tokio_stream::wrappers::ReceiverStream;
+
+/// Trait for model adapters that stream tokens for a given message.
+pub trait Model: Send + Sync {
+    /// Start generating a reply to `message`.
+    ///
+    /// Implementations return a stream of tokens which can be consumed
+    /// asynchronously to display incremental model output.
+    fn chat(&self, message: String) -> ReceiverStream<String>;
+}
+
+/// Simple model adapter that echoes the user's message back token by token.
+#[derive(Default)]
+pub struct EchoModel;
+
+impl Model for EchoModel {
+    fn chat(&self, message: String) -> ReceiverStream<String> {
+        let (tx, rx) = mpsc::channel(32);
+        tokio::spawn(async move {
+            for ch in message.chars() {
+                if tx.send(ch.to_string()).await.is_err() {
+                    break;
+                }
+                sleep(Duration::from_millis(50)).await;
+            }
+        });
+        ReceiverStream::new(rx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio_stream::StreamExt;
+
+    #[tokio::test]
+    async fn echo_model_streams() {
+        let model = EchoModel::default();
+        let stream = model.chat("hi".to_string());
+        let collected: Vec<String> = stream.collect().await;
+        assert_eq!(collected.join(""), "hi");
+    }
+}

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -1,41 +1,51 @@
 use anyhow::Result;
+use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt};
+use tokio::signal;
+use tokio_stream::StreamExt;
 
-/// Placeholder for the core interactive session.
-///
-/// The real implementation will manage conversations with an LLM and
-/// apply edits to the user's repository. For now we just record the
-/// settings and emit helpful messages so the CLI can be exercised
-/// without crashing.
-#[derive(Debug)]
+use crate::model::Model;
+
+#[derive(Default)]
+enum ChatMode {
+    /// Basic chat mode that simply streams model output.
+    #[default]
+    Echo,
+}
+
+/// Core interactive session managing state and user interaction.
 pub struct Session {
-    model: String,
+    model_name: String,
     prompt: Option<String>,
     api_key: Option<String>,
     dry_run: bool,
+    history: Vec<String>,
+    model: Box<dyn Model>,
+    chat_mode: ChatMode,
 }
 
 impl Session {
     /// Create a new session with the chosen options.
     pub fn new(
-        model: String,
+        model_name: String,
         prompt: Option<String>,
         api_key: Option<String>,
         dry_run: bool,
     ) -> Self {
+        let model: Box<dyn Model> = Box::new(crate::model::EchoModel::default());
         Self {
-            model,
+            model_name,
             prompt,
             api_key,
             dry_run,
+            history: Vec::new(),
+            model,
+            chat_mode: ChatMode::default(),
         }
     }
 
-    /// Run the session. Currently this only prints stub messages.
-    pub fn run(&mut self) -> Result<()> {
-        println!("Starting aider session with model: {}", self.model);
-        if let Some(ref msg) = self.prompt {
-            println!("Initial prompt: {msg}");
-        }
+    /// Run the interactive session.
+    pub async fn run(&mut self) -> Result<()> {
+        println!("Starting aider session with model: {}", self.model_name);
         match self.api_key {
             Some(_) => println!("API key support is not implemented; key ignored."),
             None => println!("No API key provided; network features are disabled."),
@@ -43,7 +53,72 @@ impl Session {
         if self.dry_run {
             println!("Dry-run mode selected. No changes will be written.");
         }
-        println!("Interactive editing is not implemented yet.");
+
+        if let Some(msg) = self.prompt.take() {
+            self.handle_message(msg).await?;
+        }
+
+        let stdin = io::stdin();
+        let mut reader = io::BufReader::new(stdin);
+        let mut stdout = io::stdout();
+        let mut line = String::new();
+
+        loop {
+            stdout.write_all(b"> ").await?;
+            stdout.flush().await?;
+            line.clear();
+            let bytes = reader.read_line(&mut line).await?;
+            if bytes == 0 {
+                break;
+            }
+            let input = line.trim().to_string();
+            if input.is_empty() {
+                continue;
+            }
+            if input == "/exit" || input == "/quit" {
+                break;
+            }
+            self.handle_message(input).await?;
+        }
+        Ok(())
+    }
+
+    async fn handle_message(&mut self, message: String) -> Result<()> {
+        self.history.push(message.clone());
+        match self.chat_mode {
+            ChatMode::Echo => self.stream_reply(message).await?,
+        }
+        Ok(())
+    }
+
+    async fn stream_reply(&self, message: String) -> Result<()> {
+        let mut stream = self.model.chat(message);
+        let mut stdout = io::stdout();
+        let ctrl_c = signal::ctrl_c();
+        tokio::pin!(ctrl_c);
+
+        loop {
+            tokio::select! {
+                token = stream.next() => {
+                    match token {
+                        Some(t) => {
+                            stdout.write_all(t.as_bytes()).await?;
+                            stdout.flush().await?;
+                        }
+                        None => {
+                            stdout.write_all(b"\n").await?;
+                            stdout.flush().await?;
+                            break;
+                        }
+                    }
+                }
+                _ = &mut ctrl_c => {
+                    stdout.write_all(b"\nGeneration cancelled.\n").await?;
+                    stdout.flush().await?;
+                    break;
+                }
+            }
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- implement `Model` trait with a streaming EchoModel
- add async session loop with token streaming and Ctrl-C cancel
- update CLI to drive the new session and tokio runtime

## Testing
- `cargo test --all`
- `cargo run -p aider-cli` (echo demo, canceled with Ctrl-C)


------
https://chatgpt.com/codex/tasks/task_b_68a2a15bb8dc8329b136eebcccd541f9