### PR TITLE
feat(core): add debounced file watcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,10 +43,12 @@ dependencies = [
  "anyhow",
  "axum 0.7.9",
  "clap",
+ "crossbeam-channel",
  "diffy",
  "git2",
  "ignore",
  "notify",
+ "notify-debouncer-mini",
  "reqwest",
  "rustls",
  "serde",
@@ -580,18 +582,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "filetime"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "fnv"
@@ -1138,11 +1128,11 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.9.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.2",
  "inotify-sys",
  "libc",
 ]
@@ -1258,17 +1248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
-name = "libredox"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
-dependencies = [
- "bitflags 2.9.2",
- "libc",
- "redox_syscall",
-]
-
-[[package]]
 name = "libssh2-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,23 +1330,12 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
@@ -1391,22 +1359,41 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "6.1.1"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
  "bitflags 2.9.2",
  "crossbeam-channel",
- "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
  "log",
- "mio 0.8.11",
+ "mio",
+ "notify-types",
  "walkdir",
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17849edfaabd9a5fef1c606d99cfc615a8e99f7ac4366406d86c7942a3184cf2"
+dependencies = [
+ "crossbeam-channel",
+ "log",
+ "notify",
+ "notify-types",
+ "tempfile",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2265,7 +2252,7 @@ dependencies = [
  "bytes",
  "io-uring",
  "libc",
- "mio 1.0.4",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,9 @@ tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive", "env"] }
 git2 = "0.18"
 ignore = "0.4"
-notify = "6"
+notify = "8"
+notify-debouncer-mini = { version = "0.7", features = ["crossbeam-channel"] }
+crossbeam-channel = "0.5"
 tree-sitter = "0.20"
 tree-sitter-rust = "0.20"
 tree-sitter-go = "0.20"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,6 +16,8 @@ clap = { workspace = true }
 git2 = { workspace = true }
 ignore = { workspace = true }
 notify = { workspace = true }
+notify-debouncer-mini = { workspace = true }
+crossbeam-channel = { workspace = true }
 tree-sitter = { workspace = true }
 tree-sitter-rust = { workspace = true }
 tree-sitter-go = { workspace = true }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -5,9 +5,11 @@ use tracing_subscriber::FmtSubscriber;
 pub mod git;
 pub mod model;
 pub mod session;
+pub mod watch;
 pub use git::{GitRepo, RepoStatus};
 pub use model::{EchoModel, Model};
 pub use session::Session;
+pub use watch::FileWatcher;
 
 pub fn init_tracing() -> Result<()> {
     let subscriber = FmtSubscriber::new();

--- a/crates/core/src/watch.rs
+++ b/crates/core/src/watch.rs
@@ -1,0 +1,80 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::Result;
+use crossbeam_channel::{unbounded, Receiver};
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
+use notify_debouncer_mini::notify::{Config, RecommendedWatcher, RecursiveMode};
+use notify_debouncer_mini::{
+    new_debouncer_opt, Config as DebounceConfig, DebounceEventResult, DebouncedEvent, Debouncer,
+};
+
+/// Watch file system paths for changes.
+///
+/// Events are debounced to avoid duplicate notifications when files are rapidly
+/// updated by editors. The watcher explicitly avoids following symlinks using
+/// [`Config::with_follow_symlinks(false)`] to prevent duplicate events from files
+/// that are referenced by multiple paths. A `vendor/` directory is ignored by
+/// default and won't generate events.
+pub struct FileWatcher {
+    #[allow(dead_code)]
+    debouncer: Debouncer<RecommendedWatcher>,
+    rx: Receiver<DebounceEventResult>,
+    ignore: Gitignore,
+}
+
+impl FileWatcher {
+    /// Create a new watcher for the provided paths.
+    pub fn new(paths: &[PathBuf]) -> Result<Self> {
+        let (tx, rx) = unbounded();
+        let config = DebounceConfig::default()
+            .with_timeout(Duration::from_millis(200))
+            .with_notify_config(Config::default().with_follow_symlinks(false));
+        let mut debouncer = new_debouncer_opt(config, tx)?;
+
+        for path in paths {
+            debouncer.watcher().watch(path, RecursiveMode::Recursive)?;
+        }
+
+        let mut builder = GitignoreBuilder::new("");
+        builder.add_line(None, "vendor/")?;
+        let ignore = builder.build()?;
+
+        Ok(FileWatcher {
+            debouncer,
+            rx,
+            ignore,
+        })
+    }
+
+    /// Wait for the next debounced change event.
+    ///
+    /// Returns a list of paths that were modified and not ignored. Paths are
+    /// deduplicated before being returned.
+    pub fn next(&self) -> Option<Vec<PathBuf>> {
+        while let Ok(res) = self.rx.recv() {
+            if let Ok(events) = res {
+                let mut paths = Vec::new();
+                for event in events.iter() {
+                    collect_paths(event, &self.ignore, &mut paths);
+                }
+                if !paths.is_empty() {
+                    paths.sort();
+                    paths.dedup();
+                    return Some(paths);
+                }
+            }
+        }
+        None
+    }
+}
+
+fn collect_paths(event: &DebouncedEvent, ignore: &Gitignore, out: &mut Vec<PathBuf>) {
+    let path = &event.path;
+    if !ignore
+        .matched_path_or_any_parents(path, path.is_dir())
+        .is_ignore()
+    {
+        out.push(path.clone());
+    }
+}

--- a/crates/core/tests/watch.rs
+++ b/crates/core/tests/watch.rs
@@ -1,0 +1,35 @@
+use std::fs;
+
+use aider_core::FileWatcher;
+use tempfile::tempdir;
+
+#[test]
+fn single_event_on_modify() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("file.txt");
+    fs::write(&file, b"init").unwrap();
+
+    let watcher = FileWatcher::new(&[dir.path().to_path_buf()]).unwrap();
+
+    fs::write(&file, b"changed").unwrap();
+    let paths = watcher.next().expect("event");
+    assert_eq!(paths, vec![file]);
+}
+
+#[test]
+fn symlink_does_not_duplicate() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("real.txt");
+    fs::write(&file, b"init").unwrap();
+    let link = dir.path().join("link.txt");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&file, &link).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_file(&file, &link).unwrap();
+
+    let watcher = FileWatcher::new(&[dir.path().to_path_buf()]).unwrap();
+
+    fs::write(&file, b"changed").unwrap();
+    let paths = watcher.next().expect("event");
+    assert_eq!(paths, vec![file]);
+}


### PR DESCRIPTION
## Summary
- watch configured paths with debounced notifications
- skip vendor directories and avoid following symlinks
- test single-change events and symlink handling

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68a2af2bf4408329a5a10e195766ec43