### PR TITLE
feat: add chat modes and mode command

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,3 +1,4 @@
+use aider_core::Mode;
 use anyhow::Result;
 use clap::Parser;
 
@@ -26,6 +27,10 @@ struct Args {
     #[arg(long)]
     dry_run: bool,
 
+    /// Initial chat mode
+    #[arg(long, default_value = "code")]
+    mode: String,
+
     /// Optional prompt to start the session
     #[arg()]
     prompt: Vec<String>,
@@ -41,8 +46,9 @@ async fn main() -> Result<()> {
         Some(args.prompt.join(" "))
     };
 
+    let mode: Mode = args.mode.parse().unwrap_or_default();
     let mut session =
-        aider_core::Session::new(args.model, prompt, args.openai_api_key, args.dry_run);
+        aider_core::Session::new(args.model, prompt, args.openai_api_key, args.dry_run, mode);
     session.run().await?;
     Ok(())
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2,14 +2,14 @@ use anyhow::Result;
 use tracing::info;
 use tracing_subscriber::FmtSubscriber;
 
-pub mod git;
 pub mod edit;
+pub mod git;
 pub mod session;
 pub mod watch;
 pub use aider_llm::{mock::MockProvider, ModelProvider};
-pub use git::{GitRepo, RepoStatus};
 pub use edit::{apply_diff_edit, apply_whole_file_edit};
-pub use session::Session;
+pub use git::{GitRepo, RepoStatus};
+pub use session::{Mode, Session};
 pub use watch::FileWatcher;
 
 pub fn init_tracing() -> Result<()> {

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -2,14 +2,48 @@ use anyhow::Result;
 use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt};
 use tokio::signal;
 use tokio_stream::StreamExt;
+use tracing::debug;
 
 use aider_llm::{mock::MockProvider, ChatChunk, ModelProvider};
 
-#[derive(Default)]
-enum ChatMode {
-    /// Basic chat mode that simply streams model output.
-    #[default]
-    Echo,
+/// Available chat modes that control prompting strategy.
+#[derive(Debug, Clone)]
+pub enum Mode {
+    Code,
+    Architect,
+    Ask,
+    Help,
+}
+
+impl Default for Mode {
+    fn default() -> Self {
+        Mode::Code
+    }
+}
+
+impl Mode {
+    fn system_prompt(&self) -> &'static str {
+        match self {
+            Mode::Code => "You are an AI coding assistant.",
+            Mode::Architect => "You are an AI software architect.",
+            Mode::Ask => "You are an AI assistant answering questions.",
+            Mode::Help => "You are an AI assistant offering help.",
+        }
+    }
+}
+
+impl std::str::FromStr for Mode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "code" => Ok(Mode::Code),
+            "architect" => Ok(Mode::Architect),
+            "ask" => Ok(Mode::Ask),
+            "help" => Ok(Mode::Help),
+            _ => Err(format!("unknown mode: {s}")),
+        }
+    }
 }
 
 /// Core interactive session managing state and user interaction.
@@ -20,7 +54,7 @@ pub struct Session {
     dry_run: bool,
     history: Vec<String>,
     provider: Box<dyn ModelProvider>,
-    chat_mode: ChatMode,
+    mode: Mode,
 }
 
 impl Session {
@@ -30,12 +64,14 @@ impl Session {
         prompt: Option<String>,
         api_key: Option<String>,
         dry_run: bool,
+        mode: Mode,
     ) -> Self {
         Self::with_provider(
             model_name,
             prompt,
             api_key,
             dry_run,
+            mode,
             Box::new(MockProvider::default()),
         )
     }
@@ -45,6 +81,7 @@ impl Session {
         prompt: Option<String>,
         api_key: Option<String>,
         dry_run: bool,
+        mode: Mode,
         provider: Box<dyn ModelProvider>,
     ) -> Self {
         Self {
@@ -54,7 +91,7 @@ impl Session {
             dry_run,
             history: Vec::new(),
             provider,
-            chat_mode: ChatMode::default(),
+            mode,
         }
     }
 
@@ -99,15 +136,47 @@ impl Session {
     }
 
     async fn handle_message(&mut self, message: String) -> Result<()> {
-        self.history.push(message.clone());
-        match self.chat_mode {
-            ChatMode::Echo => self.stream_reply(message).await?,
+        if let Some(rest) = message.strip_prefix("/mode ") {
+            match rest.parse::<Mode>() {
+                Ok(mode) => {
+                    self.mode = mode;
+                    debug!("switched mode"=?self.mode, prompt=self.mode.system_prompt());
+                }
+                Err(err) => println!("{err}"),
+            }
+            return Ok(());
         }
+        if let Some(rest) = message.strip_prefix("/ask ") {
+            self.stream_reply_with_mode(Mode::Ask, rest.to_string())
+                .await?;
+            return Ok(());
+        }
+        if let Some(rest) = message.strip_prefix("/help ") {
+            self.stream_reply_with_mode(Mode::Help, rest.to_string())
+                .await?;
+            return Ok(());
+        }
+        if let Some(rest) = message.strip_prefix("/architect ") {
+            self.stream_reply_with_mode(Mode::Architect, rest.to_string())
+                .await?;
+            return Ok(());
+        }
+        if let Some(rest) = message.strip_prefix("/code ") {
+            self.stream_reply_with_mode(Mode::Code, rest.to_string())
+                .await?;
+            return Ok(());
+        }
+        self.history.push(message.clone());
+        self.stream_reply_with_mode(self.mode.clone(), message)
+            .await?;
         Ok(())
     }
 
-    async fn stream_reply(&self, message: String) -> Result<()> {
-        let mut stream = self.provider.chat(message);
+    async fn stream_reply_with_mode(&self, mode: Mode, message: String) -> Result<()> {
+        let system_prompt = mode.system_prompt();
+        debug!(mode=?mode, prompt=system_prompt);
+        let prompt = format!("{}\n{}", system_prompt, message);
+        let mut stream = self.provider.chat(prompt);
         let mut stdout = io::stdout();
         let ctrl_c = signal::ctrl_c();
         tokio::pin!(ctrl_c);
@@ -145,13 +214,23 @@ impl Session {
 mod tests {
     use super::*;
     use aider_llm::ChatChunk;
+    use aider_llm::Usage;
+    use std::sync::{Arc, Mutex};
+    use tokio::sync::mpsc;
+    use tokio_stream::wrappers::ReceiverStream;
     use tokio_stream::StreamExt;
 
     #[tokio::test]
     async fn session_uses_mock_provider() {
         let provider = MockProvider::new_with_tokens(vec!["hi".into()]);
-        let session =
-            Session::with_provider("mock".into(), None, None, false, Box::new(provider.clone()));
+        let session = Session::with_provider(
+            "mock".into(),
+            None,
+            None,
+            false,
+            Mode::Code,
+            Box::new(provider.clone()),
+        );
         let stream = provider.chat("ignored".into());
         let chunks: Vec<ChatChunk> = stream.collect().await;
         let tokens: Vec<String> = chunks
@@ -163,6 +242,49 @@ mod tests {
             .collect();
         assert_eq!(tokens, vec!["hi"]);
         // ensure session can call stream_reply without error
-        session.stream_reply("test".into()).await.unwrap();
+        session
+            .stream_reply_with_mode(Mode::Code, "test".into())
+            .await
+            .unwrap();
+    }
+
+    #[derive(Clone)]
+    struct CaptureProvider {
+        last: Arc<Mutex<Option<String>>>,
+    }
+
+    impl ModelProvider for CaptureProvider {
+        fn chat(&self, prompt: String) -> ReceiverStream<ChatChunk> {
+            *self.last.lock().unwrap() = Some(prompt);
+            let (tx, rx) = mpsc::channel(1);
+            drop(tx);
+            ReceiverStream::new(rx)
+        }
+
+        fn usage(&self) -> Usage {
+            Usage::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn mode_affects_prompt() {
+        let last = Arc::new(Mutex::new(None));
+        let provider = CaptureProvider { last: last.clone() };
+        let mut session = Session::with_provider(
+            "mock".into(),
+            None,
+            None,
+            false,
+            Mode::Code,
+            Box::new(provider),
+        );
+        session.handle_message("hi".into()).await.unwrap();
+        let prompt1 = last.lock().unwrap().clone().unwrap();
+        assert!(prompt1.starts_with(Mode::Code.system_prompt()));
+
+        session.handle_message("/mode help".into()).await.unwrap();
+        session.handle_message("question".into()).await.unwrap();
+        let prompt2 = last.lock().unwrap().clone().unwrap();
+        assert!(prompt2.starts_with(Mode::Help.system_prompt()));
     }
 }


### PR DESCRIPTION
## Summary
- add Mode enum with code, architect, ask and help variants
- support /mode command and per-mode prompts with debug logging
- expose --mode flag in CLI to choose initial chat mode

## Testing
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_b_68a3f87601c88329856571b3a01d1ae7