### PR TITLE
Add runner trait and auto-fix workflow

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -27,6 +27,18 @@ struct Args {
     #[arg(long)]
     dry_run: bool,
 
+    /// Skip running linters
+    #[arg(long)]
+    no_lint: bool,
+
+    /// Skip running tests
+    #[arg(long)]
+    no_test: bool,
+
+    /// Maximum number of automatic fix attempts
+    #[arg(long, default_value_t = 1)]
+    max_fix_attempts: u32,
+
     /// Initial chat mode
     #[arg(long, default_value = "code")]
     mode: String,
@@ -47,8 +59,16 @@ async fn main() -> Result<()> {
     };
 
     let mode: Mode = args.mode.parse().unwrap_or_default();
-    let mut session =
-        aider_core::Session::new(args.model, prompt, args.openai_api_key, args.dry_run, mode);
+    let mut session = aider_core::Session::new(
+        args.model,
+        prompt,
+        args.openai_api_key,
+        args.dry_run,
+        mode,
+        args.no_lint,
+        args.no_test,
+        args.max_fix_attempts,
+    );
     session.run().await?;
     Ok(())
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,11 +7,13 @@ pub mod edit;
 pub mod git;
 pub mod session;
 pub mod watch;
+pub mod runner;
 pub use aider_llm::{mock::MockProvider, ModelProvider};
 pub use command::Command;
 pub use edit::{apply_diff_edit, apply_whole_file_edit};
 pub use git::{GitRepo, RepoStatus};
 pub use session::{Mode, Session};
+pub use runner::{Runner, RustRunner, JsRunner, RunOptions, CommandResult, apply_with_runner};
 pub use watch::FileWatcher;
 
 pub fn init_tracing() -> Result<()> {

--- a/crates/core/src/runner.rs
+++ b/crates/core/src/runner.rs
@@ -1,0 +1,155 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use anyhow::Result;
+
+/// Result of running a command.
+#[derive(Debug, Default, Clone)]
+pub struct CommandResult {
+    pub command: String,
+    pub stdout: String,
+    pub stderr: String,
+    pub status: i32,
+}
+
+fn run_command(cmd: &mut Command, cwd: &Path) -> Result<CommandResult> {
+    let output = cmd.current_dir(cwd).output()?;
+    Ok(CommandResult {
+        command: format!("{:?}", cmd),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        status: output.status.code().unwrap_or_default(),
+    })
+}
+
+/// Generic interface for language-specific linters and test runners.
+pub trait Runner {
+    /// Name of the runner implementation.
+    fn name(&self) -> &str;
+    /// Run lint and/or tests and return command results.
+    fn run(&self, no_lint: bool, no_test: bool) -> Result<Vec<CommandResult>>;
+}
+
+/// Runner implementation for Rust projects using Cargo.
+pub struct RustRunner {
+    root: PathBuf,
+}
+
+impl RustRunner {
+    pub fn new(root: impl AsRef<Path>) -> Self {
+        Self { root: root.as_ref().to_path_buf() }
+    }
+}
+
+impl Runner for RustRunner {
+    fn name(&self) -> &str {
+        "rust"
+    }
+
+    fn run(&self, no_lint: bool, no_test: bool) -> Result<Vec<CommandResult>> {
+        let mut results = Vec::new();
+        if !no_lint {
+            let mut cmd = Command::new("cargo");
+            cmd.arg("clippy");
+            results.push(run_command(&mut cmd, &self.root)?);
+        }
+        if !no_test {
+            let mut cmd = Command::new("cargo");
+            cmd.arg("test");
+            results.push(run_command(&mut cmd, &self.root)?);
+        }
+        Ok(results)
+    }
+}
+
+/// Runner implementation for JavaScript projects using npm.
+pub struct JsRunner {
+    root: PathBuf,
+}
+
+impl JsRunner {
+    pub fn new(root: impl AsRef<Path>) -> Self {
+        Self { root: root.as_ref().to_path_buf() }
+    }
+}
+
+impl Runner for JsRunner {
+    fn name(&self) -> &str {
+        "javascript"
+    }
+
+    fn run(&self, no_lint: bool, no_test: bool) -> Result<Vec<CommandResult>> {
+        let mut results = Vec::new();
+        if !no_test {
+            let mut cmd = Command::new("npm");
+            cmd.arg("test");
+            results.push(run_command(&mut cmd, &self.root)?);
+        }
+        if !no_lint {
+            let mut cmd = Command::new("npm");
+            cmd.arg("run").arg("lint");
+            results.push(run_command(&mut cmd, &self.root)?);
+        }
+        Ok(results)
+    }
+}
+
+/// Options controlling how runners are executed.
+#[derive(Debug, Clone, Copy)]
+pub struct RunOptions {
+    pub no_lint: bool,
+    pub no_test: bool,
+    pub max_fix_attempts: u32,
+}
+
+impl Default for RunOptions {
+    fn default() -> Self {
+        Self {
+            no_lint: false,
+            no_test: false,
+            max_fix_attempts: 1,
+        }
+    }
+}
+
+/// Summarize output by returning the first `n` lines and the exit status.
+pub fn summarize_output(text: &str, n: usize, status: i32) -> String {
+    let lines: Vec<&str> = text.lines().take(n).collect();
+    let mut summary = lines.join("\n");
+    summary.push_str(&format!("\n(exit status: {status})"));
+    summary
+}
+
+/// Apply a change and run runners, attempting to fix failures once.
+pub async fn apply_with_runner(
+    provider: &dyn crate::ModelProvider,
+    repo: &crate::GitRepo,
+    runner: &dyn Runner,
+    file: &Path,
+    change_request: &str,
+    commit_message: &str,
+    opts: RunOptions,
+) -> Result<Vec<CommandResult>> {
+    crate::apply_diff_edit(provider, repo, file, change_request, commit_message).await?;
+    let mut attempts = 0;
+    loop {
+        let results = runner.run(opts.no_lint, opts.no_test)?;
+        let failed = results.iter().find(|r| r.status != 0);
+        if failed.is_none() {
+            return Ok(results);
+        }
+        attempts += 1;
+        if attempts > opts.max_fix_attempts {
+            return Ok(results);
+        }
+        let failure = failed.unwrap();
+        let summary = summarize_output(&failure.stderr, 20, failure.status);
+        let fix_request = format!(
+            "The following run of `{}` failed:\n{}\nPlease fix the code in {} so that the run succeeds.",
+            failure.command,
+            summary,
+            file.display(),
+        );
+        crate::apply_diff_edit(provider, repo, file, &fix_request, "auto-fix").await?;
+    }
+}
+

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -62,6 +62,9 @@ pub struct Session {
     root: PathBuf,
     files: HashSet<PathBuf>,
     state_path: PathBuf,
+    no_lint: bool,
+    no_test: bool,
+    max_fix_attempts: u32,
 }
 
 #[derive(Serialize, Deserialize, Default)]
@@ -78,6 +81,9 @@ impl Session {
         api_key: Option<String>,
         dry_run: bool,
         mode: Mode,
+        no_lint: bool,
+        no_test: bool,
+        max_fix_attempts: u32,
     ) -> Self {
         let root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
         Self::with_provider(
@@ -86,6 +92,9 @@ impl Session {
             api_key,
             dry_run,
             mode,
+            no_lint,
+            no_test,
+            max_fix_attempts,
             Box::new(MockProvider::default()),
             root,
         )
@@ -97,6 +106,9 @@ impl Session {
         api_key: Option<String>,
         dry_run: bool,
         mode: Mode,
+        no_lint: bool,
+        no_test: bool,
+        max_fix_attempts: u32,
         provider: Box<dyn ModelProvider>,
         root: PathBuf,
     ) -> Self {
@@ -112,6 +124,9 @@ impl Session {
             root,
             files: HashSet::new(),
             state_path,
+            no_lint,
+            no_test,
+            max_fix_attempts,
         };
         session.load_state();
         session
@@ -344,6 +359,9 @@ mod tests {
             None,
             false,
             Mode::Code,
+            false,
+            false,
+            1,
             Box::new(provider.clone()),
             dir.path().to_path_buf(),
         );
@@ -393,6 +411,9 @@ mod tests {
             None,
             false,
             Mode::Code,
+            false,
+            false,
+            1,
             Box::new(provider),
             dir.path().to_path_buf(),
         );
@@ -418,6 +439,9 @@ mod tests {
             None,
             false,
             Mode::Code,
+            false,
+            false,
+            1,
             Box::new(provider),
             dir.path().to_path_buf(),
         );

--- a/crates/core/tests/auto_fix.rs
+++ b/crates/core/tests/auto_fix.rs
@@ -1,0 +1,78 @@
+use std::fs;
+use std::path::PathBuf;
+use anyhow::Result;
+use aider_core::{apply_with_runner, GitRepo, RunOptions, RustRunner, ModelProvider};
+use aider_llm::{ChatChunk, Usage};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tempfile::tempdir;
+use std::sync::Mutex;
+
+struct SeqProvider {
+    responses: Mutex<Vec<Vec<String>>>,
+}
+
+impl SeqProvider {
+    fn new(responses: Vec<Vec<String>>) -> Self {
+        Self { responses: Mutex::new(responses) }
+    }
+}
+
+impl ModelProvider for SeqProvider {
+    fn chat(&self, _prompt: String) -> ReceiverStream<ChatChunk> {
+        let tokens = {
+            let mut lock = self.responses.lock().unwrap();
+            if lock.is_empty() { Vec::new() } else { lock.remove(0) }
+        };
+        let (tx, rx) = mpsc::channel(32);
+        tokio::spawn(async move {
+            for tok in tokens {
+                let _ = tx.send(ChatChunk::Token(tok)).await;
+            }
+        });
+        ReceiverStream::new(rx)
+    }
+
+    fn usage(&self) -> Usage {
+        Usage::default()
+    }
+}
+
+#[tokio::test]
+async fn auto_fix_rust_runner() -> Result<()> {
+    let dir = tempdir()?;
+    fs::create_dir(dir.path().join("src"))?;
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname=\"tmp\"\nversion=\"0.1.0\"\nedition=\"2021\"\n",
+    )?;
+    fs::write(
+        dir.path().join("src/lib.rs"),
+        "pub fn add(a:i32,b:i32)->i32{a+b}\n\n#[cfg(test)]\nmod tests{use super::*;#[test]fn it_adds(){assert_eq!(add(1,1),2);}}\n",
+    )?;
+    git2::Repository::init(dir.path())?;
+    let git = GitRepo::open(dir.path())?;
+    git.stage("Cargo.toml")?;
+    git.stage(PathBuf::from("src/lib.rs"))?;
+    git.commit("init")?;
+
+    let bug_patch = "```diff\n@@\n-pub fn add(a:i32,b:i32)->i32{a+b}\n+pub fn add(a:i32,b:i32)->i32{a-b}\n```";
+    let fix_patch = "```diff\n@@\n-pub fn add(a:i32,b:i32)->i32{a-b}\n+pub fn add(a:i32,b:i32)->i32{a+b}\n```";
+    let provider = SeqProvider::new(vec![vec![bug_patch.into()], vec![fix_patch.into()]]);
+    let runner = RustRunner::new(dir.path());
+    let file_rel = PathBuf::from("src/lib.rs");
+    let opts = RunOptions { no_lint: true, no_test: false, max_fix_attempts: 1 };
+    let results = apply_with_runner(
+        &provider,
+        &git,
+        &runner,
+        &file_rel,
+        "introduce bug",
+        "bug",
+        opts,
+    )
+    .await?;
+    assert!(results.iter().all(|r| r.status == 0));
+    Ok(())
+}
+


### PR DESCRIPTION
## Summary
- add configurable Runner trait with Rust and JS implementations
- invoke runners after edits with optional auto-fix retries
- expose --no-lint, --no-test and --max-fix-attempts CLI flags

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68a40425b6988329b3dca3ac46eb17c1