### PR TITLE
Add Flutter gRPC skeleton with chat and file panels

### DIFF
--- a/flutter_app/lib/grpc_client.dart
+++ b/flutter_app/lib/grpc_client.dart
@@ -1,0 +1,67 @@
+import 'package:grpc/grpc.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import 'gen/proto/aider.pbgrpc.dart';
+
+/// Helper class managing gRPC and WebSocket connections to the aider server.
+class AiderConnection {
+  final ClientChannel channel;
+  final SessionServiceClient session;
+  final RepoMapServiceClient repoMap;
+  final DiffServiceClient diff;
+  final String sessionId;
+  final WebSocketChannel ws;
+
+  AiderConnection._(
+    this.channel,
+    this.session,
+    this.repoMap,
+    this.diff,
+    this.sessionId,
+    this.ws,
+  );
+
+  /// Connect to the aider server at [url].
+  ///
+  /// This opens a gRPC channel and session and establishes a WebSocket
+  /// connection for streaming tokens.
+  static Future<AiderConnection> connect(String url) async {
+    final uri = Uri.parse(url);
+    final channel = ClientChannel(
+      uri.host,
+      port: uri.port,
+      options: ChannelOptions(
+        credentials: uri.scheme == 'https'
+            ? const ChannelCredentials.secure()
+            : const ChannelCredentials.insecure(),
+      ),
+    );
+
+    final sessionClient = SessionServiceClient(channel);
+    final repoClient = RepoMapServiceClient(channel);
+    final diffClient = DiffServiceClient(channel);
+
+    final openResp = await sessionClient.open(
+      OpenRequest(clientVersion: 'flutter'),
+    );
+
+    final wsScheme = uri.scheme == 'https' ? 'wss' : 'ws';
+    final wsUrl = Uri.parse('$wsScheme://${uri.authority}/ws/${openResp.sessionId}');
+    final ws = WebSocketChannel.connect(wsUrl);
+
+    return AiderConnection._(
+      channel,
+      sessionClient,
+      repoClient,
+      diffClient,
+      openResp.sessionId,
+      ws,
+    );
+  }
+
+  /// Close both the gRPC channel and WebSocket connection.
+  Future<void> close() async {
+    await ws.sink.close();
+    await channel.shutdown();
+  }
+}

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -1,142 +1,221 @@
-import 'package:dio/dio.dart';
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
-import 'package:web_socket_channel/web_socket_channel.dart';
 
-import 'api.dart' as api;
-import 'chat_database.dart';
-import 'frb_generated.dart';
-import 'widgets.dart';
+import 'grpc_client.dart';
+import 'gen/proto/aider.pbgrpc.dart';
 
-Future<void> main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  await RustLib.init();
-  final db = await ChatDatabase.open();
-  runApp(MyApp(db: db));
+void main() {
+  runApp(const MyApp());
 }
 
-class MyApp extends StatelessWidget {
-  final ChatDatabase db;
-  const MyApp({super.key, required this.db});
+class MyApp extends StatefulWidget {
+  const MyApp({super.key});
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  AiderConnection? _conn;
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Aider Flutter',
-      home: HomePage(db: db),
+      home: _conn == null
+          ? ConnectionPage(onConnected: (c) => setState(() => _conn = c))
+          : HomePage(connection: _conn!),
+    );
+  }
+}
+
+class ConnectionPage extends StatefulWidget {
+  final ValueChanged<AiderConnection> onConnected;
+  const ConnectionPage({super.key, required this.onConnected});
+
+  @override
+  State<ConnectionPage> createState() => _ConnectionPageState();
+}
+
+class _ConnectionPageState extends State<ConnectionPage> {
+  final _controller = TextEditingController(text: 'http://localhost:8080');
+  bool _busy = false;
+  String? _error;
+
+  Future<void> _connect() async {
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final conn = await AiderConnection.connect(_controller.text);
+      widget.onConnected(conn);
+    } catch (e) {
+      setState(() {
+        _error = '$e';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _busy = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Connect')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _controller,
+              decoration: const InputDecoration(labelText: 'Server URL'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _busy ? null : _connect,
+              child: const Text('Connect'),
+            ),
+            if (_error != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Text(_error!, style: const TextStyle(color: Colors.red)),
+              ),
+          ],
+        ),
+      ),
     );
   }
 }
 
 class HomePage extends StatefulWidget {
-  final ChatDatabase db;
-  const HomePage({super.key, required this.db});
+  final AiderConnection connection;
+  const HomePage({super.key, required this.connection});
 
   @override
   State<HomePage> createState() => _HomePageState();
 }
 
 class _HomePageState extends State<HomePage> {
-  final dio = Dio();
-  late final WebSocketChannel channel;
   int _index = 0;
-
-  @override
-  void initState() {
-    super.initState();
-    channel = WebSocketChannel.connect(
-      Uri.parse('wss://echo.websocket.events'),
-    );
-    channel.stream.listen((event) {
-      // handle incoming messages
-    });
-  }
-
-  @override
-  void dispose() {
-    channel.sink.close();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
     final pages = [
-      ChatPage(db: widget.db, dio: dio, channel: channel),
-      const RepoNavigatorPage(),
+      ChatPage(connection: widget.connection),
+      FilesPage(connection: widget.connection),
     ];
     return Scaffold(
       body: pages[_index],
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: _index,
+        onTap: (i) => setState(() => _index = i),
         items: const [
           BottomNavigationBarItem(icon: Icon(Icons.chat), label: 'Chat'),
-          BottomNavigationBarItem(icon: Icon(Icons.folder), label: 'Repos'),
+          BottomNavigationBarItem(icon: Icon(Icons.folder), label: 'Files'),
         ],
-        onTap: (i) => setState(() => _index = i),
       ),
     );
   }
 }
 
 class ChatPage extends StatefulWidget {
-  final ChatDatabase db;
-  final Dio dio;
-  final WebSocketChannel channel;
-
-  const ChatPage({
-    super.key,
-    required this.db,
-    required this.dio,
-    required this.channel,
-  });
+  final AiderConnection connection;
+  const ChatPage({super.key, required this.connection});
 
   @override
   State<ChatPage> createState() => _ChatPageState();
 }
 
+class _Message {
+  _Message(this.role, this.text);
+  final String role;
+  String text;
+}
+
 class _ChatPageState extends State<ChatPage> {
-  final controller = TextEditingController();
-  String diff = '';
-  String webContent = '';
+  final List<_Message> _messages = [];
+  StreamSubscription? _sub;
+  TextEditingController? _inputController;
+  static const _commands = ['/add', '/drop', '/help'];
+
+  @override
+  void initState() {
+    super.initState();
+    _sub = widget.connection.ws.stream.listen((event) {
+      setState(() {
+        if (_messages.isNotEmpty && _messages.last.role == 'assistant') {
+          _messages.last.text += event.toString();
+        } else {
+          _messages.add(_Message('assistant', event.toString()));
+        }
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
 
   Future<void> _send() async {
-    final text = controller.text;
-    controller.clear();
-    final response = await api.llm(prompt: text);
-    widget.db.addMessage(text, response);
-    await api.analyticsEvent(event: 'message', properties: '{}');
-    widget.channel.sink.add(text);
-    setState(() {});
-  }
-
-  Future<void> _showDiff() async {
-    final output = await api.git(command: 'diff');
-    setState(() => diff = output);
-  }
-
-  Future<void> _scrape(String url) async {
-    final result = await api.scrapeUrl(url: url);
-    setState(() => webContent = result);
-  }
-
-  Future<void> _undo() async {
-    widget.db.deleteLastMessage();
-    setState(() {});
+    final text = _inputController?.text ?? '';
+    if (text.isEmpty) return;
+    _inputController!.clear();
+    setState(() {
+      _messages.add(_Message('user', text));
+      _messages.add(_Message('assistant', ''));
+    });
+    await widget.connection.session.sendMessage(
+      SendMessageRequest(sessionId: widget.connection.sessionId, message: text),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
     return Column(
       children: [
-        Expanded(child: ChatHistory(db: widget.db)),
-        FileDiffViewer(diff: diff),
-        FileDiffViewer(diff: webContent),
-        WebContentInput(onSubmit: _scrape),
+        Expanded(
+          child: ListView(
+            children: _messages
+                .map((m) => ListTile(
+                      title: Text(m.text),
+                      subtitle: Text(m.role),
+                    ))
+                .toList(),
+          ),
+        ),
         Row(
           children: [
-            Expanded(child: TextField(controller: controller)),
-            UndoButton(onPressed: _undo),
-            IconButton(icon: const Icon(Icons.code), onPressed: _showDiff),
-            IconButton(icon: const Icon(Icons.send), onPressed: _send),
+            Expanded(
+              child: Autocomplete<String>(
+                optionsBuilder: (value) {
+                  if (!value.text.startsWith('/')) {
+                    return const Iterable<String>.empty();
+                  }
+                  return _commands.where((c) => c.startsWith(value.text));
+                },
+                fieldViewBuilder: (context, controller, focusNode, onFieldSubmitted) {
+                  _inputController = controller;
+                  return TextField(
+                    controller: controller,
+                    focusNode: focusNode,
+                    onSubmitted: (_) => _send(),
+                  );
+                },
+                onSelected: (s) {
+                  _inputController?.text = s;
+                },
+              ),
+            ),
+            IconButton(onPressed: _send, icon: const Icon(Icons.send)),
           ],
         ),
       ],
@@ -144,16 +223,77 @@ class _ChatPageState extends State<ChatPage> {
   }
 }
 
-class RepoNavigatorPage extends StatelessWidget {
-  const RepoNavigatorPage({super.key});
+class FilesPage extends StatefulWidget {
+  final AiderConnection connection;
+  const FilesPage({super.key, required this.connection});
+
+  @override
+  State<FilesPage> createState() => _FilesPageState();
+}
+
+class _FilesPageState extends State<FilesPage> {
+  late Future<List<String>> _files;
+  final Set<String> _selected = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _files = _load();
+  }
+
+  Future<List<String>> _load() async {
+    final resp = await widget.connection.repoMap.getMap(
+      GetMapRequest(sessionId: widget.connection.sessionId),
+    );
+    final data = jsonDecode(resp.mapJson);
+    final List<String> out = [];
+    if (data is Map && data['files'] is List) {
+      for (var f in data['files']) {
+        if (f is String) {
+          out.add(f);
+        } else if (f is Map && f['path'] is String) {
+          out.add(f['path'] as String);
+        }
+      }
+    }
+    return out;
+  }
+
+  Future<void> _toggle(String path, bool checked) async {
+    setState(() {
+      if (checked) {
+        _selected.add(path);
+      } else {
+        _selected.remove(path);
+      }
+    });
+    final files = _selected
+        .map((p) => SetFilesRequest_File(path: p, content: ''))
+        .toList();
+    await widget.connection.session.setFiles(
+      SetFilesRequest(sessionId: widget.connection.sessionId, files: files),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder(
-      future: api.repoMap(),
+    return FutureBuilder<List<String>>(
+      future: _files,
       builder: (context, snapshot) {
-        return Center(
-          child: Text(snapshot.data ?? 'Loading...'),
+        if (!snapshot.hasData) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final files = snapshot.data!;
+        return ListView(
+          children: files
+              .map(
+                (f) => CheckboxListTile(
+                  title: Text(f),
+                  value: _selected.contains(f),
+                  onChanged: (v) => _toggle(f, v ?? false),
+                ),
+              )
+              .toList(),
         );
       },
     );

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -13,6 +13,8 @@ dependencies:
   sqlite3_flutter_libs: ^0.5.0
   dio: ^5.4.0
   web_socket_channel: ^2.4.0
+  grpc: ^3.2.4
+  protobuf: ^3.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add gRPC and protobuf dependencies
- implement AiderConnection to open gRPC session and WebSocket stream
- add connection, chat, and file selection screens in Flutter app

## Testing
- `pre-commit run --files flutter_app/pubspec.yaml flutter_app/lib/main.dart flutter_app/lib/grpc_client.dart`
- `dart format flutter_app/lib/main.dart flutter_app/lib/grpc_client.dart flutter_app/pubspec.yaml` (fails: command not found)
- `flutter analyze flutter_app` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_b_68a423a2540c83299b9c77f8953c31a8