### PR TITLE
feat: add Go proxy bridge with Rust provider

### DIFF
--- a/aider-go-bridge/go.mod
+++ b/aider-go-bridge/go.mod
@@ -1,0 +1,5 @@
+module aider-go-bridge
+
+go 1.21
+
+require golang.org/x/time v0.3.0

--- a/aider-go-bridge/go.sum
+++ b/aider-go-bridge/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
+golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/aider-go-bridge/main.go
+++ b/aider-go-bridge/main.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type CompleteRequest struct {
+	Model       string    `json:"model"`
+	Messages    []Message `json:"messages"`
+	Tools       any       `json:"tools,omitempty"`
+	MaxTokens   int       `json:"max_tokens,omitempty"`
+	Temperature float32   `json:"temperature,omitempty"`
+}
+
+type Backend interface {
+	Complete(ctx context.Context, req CompleteRequest, w http.ResponseWriter) error
+}
+
+type EchoBackend struct{}
+
+func (e *EchoBackend) Complete(ctx context.Context, req CompleteRequest, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return fmt.Errorf("streaming not supported")
+	}
+	if len(req.Messages) == 0 {
+		return nil
+	}
+	text := req.Messages[len(req.Messages)-1].Content
+	for _, r := range text {
+		out, _ := json.Marshal(map[string]string{"token": string(r)})
+		fmt.Fprintln(w, string(out))
+		flusher.Flush()
+		time.Sleep(10 * time.Millisecond)
+	}
+	out, _ := json.Marshal(map[string]bool{"done": true})
+	fmt.Fprintln(w, string(out))
+	flusher.Flush()
+	return nil
+}
+
+type OpenAIBackend struct {
+	apiKey string
+	client *http.Client
+}
+
+func (o *OpenAIBackend) Complete(ctx context.Context, req CompleteRequest, w http.ResponseWriter) error {
+	body := map[string]any{
+		"model":    req.Model,
+		"messages": req.Messages,
+		"stream":   true,
+	}
+	if req.MaxTokens > 0 {
+		body["max_tokens"] = req.MaxTokens
+	}
+	if req.Temperature > 0 {
+		body["temperature"] = req.Temperature
+	}
+	b, _ := json.Marshal(body)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.openai.com/v1/chat/completions", bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+o.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := o.client.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		w.WriteHeader(resp.StatusCode)
+		io.Copy(w, resp.Body)
+		return nil
+	}
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return fmt.Errorf("streaming not supported")
+	}
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "[DONE]" {
+			break
+		}
+		var v struct {
+			Choices []struct {
+				Delta struct {
+					Content string `json:"content"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(data), &v); err != nil {
+			continue
+		}
+		if len(v.Choices) > 0 {
+			token := v.Choices[0].Delta.Content
+			if token != "" {
+				out, _ := json.Marshal(map[string]string{"token": token})
+				w.Write(out)
+				w.Write([]byte("\n"))
+				flusher.Flush()
+			}
+		}
+	}
+	out, _ := json.Marshal(map[string]bool{"done": true})
+	w.Write(out)
+	w.Write([]byte("\n"))
+	flusher.Flush()
+	return nil
+}
+
+func newBackend() Backend {
+	if key := os.Getenv("OPENAI_API_KEY"); key != "" {
+		return &OpenAIBackend{apiKey: key, client: &http.Client{}}
+	}
+	return &EchoBackend{}
+}
+
+var (
+	backend  Backend
+	limiters sync.Map // map[string]*rate.Limiter
+)
+
+func getLimiter(model string) *rate.Limiter {
+	if v, ok := limiters.Load(model); ok {
+		return v.(*rate.Limiter)
+	}
+	envName := "RATE_LIMIT_" + strings.ToUpper(strings.ReplaceAll(model, "-", "_"))
+	perMin := 60
+	if s := os.Getenv(envName); s != "" {
+		if i, err := strconv.Atoi(s); err == nil && i > 0 {
+			perMin = i
+		}
+	}
+	l := rate.NewLimiter(rate.Every(time.Minute/time.Duration(perMin)), perMin)
+	limiters.Store(model, l)
+	return l
+}
+
+func completeHandler(w http.ResponseWriter, r *http.Request) {
+	var req CompleteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	if req.Model == "" {
+		http.Error(w, "model required", http.StatusBadRequest)
+		return
+	}
+	if !getLimiter(req.Model).Allow() {
+		http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+		return
+	}
+	if err := backend.Complete(r.Context(), req, w); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("{\"status\":\"ok\"}"))
+}
+
+func main() {
+	backend = newBackend()
+	http.HandleFunc("/complete", completeHandler)
+	http.HandleFunc("/health", healthHandler)
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Printf("listening on :%s", port)
+	log.Fatal(http.ListenAndServe(":"+port, nil))
+}

--- a/crates/llm/src/go_proxy.rs
+++ b/crates/llm/src/go_proxy.rs
@@ -1,0 +1,150 @@
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use bytes::Bytes;
+use reqwest::Client;
+use serde_json::{json, Value};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_stream::StreamExt;
+
+use crate::{ChatChunk, ModelProvider, Usage};
+
+#[derive(Clone)]
+pub struct GoProxyConfig {
+    pub base_url: String,
+    pub model: String,
+    pub temperature: Option<f32>,
+    pub max_tokens: Option<u32>,
+}
+
+impl GoProxyConfig {
+    pub fn from_env() -> Self {
+        Self {
+            base_url: std::env::var("GO_PROXY_URL")
+                .unwrap_or_else(|_| "http://localhost:8080".into()),
+            model: std::env::var("GO_PROXY_MODEL").unwrap_or_else(|_| "gpt-4o".into()),
+            temperature: None,
+            max_tokens: None,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct GoProxyProvider {
+    client: Client,
+    cfg: GoProxyConfig,
+    usage: Arc<Mutex<Usage>>,
+}
+
+impl GoProxyProvider {
+    pub fn new(cfg: GoProxyConfig) -> Self {
+        Self {
+            client: Client::new(),
+            usage: Arc::new(Mutex::new(Usage::default())),
+            cfg,
+        }
+    }
+
+    fn build_body(&self, prompt: String) -> Value {
+        let mut body = json!({
+            "model": self.cfg.model,
+            "messages": [ {"role": "user", "content": prompt} ],
+        });
+        if let Some(t) = self.cfg.temperature {
+            body["temperature"] = json!(t);
+        }
+        if let Some(mt) = self.cfg.max_tokens {
+            body["max_tokens"] = json!(mt);
+        }
+        body
+    }
+
+    async fn process_stream<S>(mut stream: S, tx: mpsc::Sender<ChatChunk>)
+    where
+        S: tokio_stream::Stream<Item = Result<Bytes, reqwest::Error>> + Unpin,
+    {
+        let mut buf = String::new();
+        while let Some(chunk) = stream.next().await {
+            match chunk {
+                Ok(bytes) => {
+                    buf.push_str(&String::from_utf8_lossy(&bytes));
+                    while let Some(pos) = buf.find('\n') {
+                        let line = buf[..pos].to_string();
+                        buf = buf[pos + 1..].to_string();
+                        if line.trim().is_empty() {
+                            continue;
+                        }
+                        if let Ok(json) = serde_json::from_str::<Value>(&line) {
+                            if let Some(token) = json.get("token").and_then(|t| t.as_str()) {
+                                let _ = tx.send(ChatChunk::Token(token.to_string())).await;
+                            }
+                            if json.get("done").and_then(|d| d.as_bool()) == Some(true) {
+                                return;
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    let _ = tx.send(ChatChunk::Token(format!("error: {}", e))).await;
+                    return;
+                }
+            }
+        }
+    }
+
+    async fn send_request(&self, prompt: String, tx: mpsc::Sender<ChatChunk>) {
+        let url = format!("{}/complete", self.cfg.base_url.trim_end_matches('/'));
+        let body = self.build_body(prompt);
+        let mut attempt: u32 = 0;
+        loop {
+            attempt += 1;
+            let res = self.client.post(&url).json(&body).send().await;
+            match res {
+                Ok(r) if r.status().is_success() => {
+                    let stream = r.bytes_stream();
+                    Self::process_stream(stream, tx).await;
+                    break;
+                }
+                Ok(r) if r.status().as_u16() == 429 || r.status().is_server_error() => {
+                    if attempt >= 3 {
+                        let _ = tx
+                            .send(ChatChunk::Token("error: too many retries".into()))
+                            .await;
+                        break;
+                    }
+                    let backoff = 2u64.pow(attempt);
+                    tokio::time::sleep(Duration::from_secs(backoff)).await;
+                }
+                Ok(r) => {
+                    let msg = format!("error: HTTP {}", r.status());
+                    let _ = tx.send(ChatChunk::Token(msg)).await;
+                    break;
+                }
+                Err(e) => {
+                    if attempt >= 3 {
+                        let _ = tx.send(ChatChunk::Token(format!("error: {}", e))).await;
+                        break;
+                    }
+                    let backoff = 2u64.pow(attempt);
+                    tokio::time::sleep(Duration::from_secs(backoff)).await;
+                }
+            }
+        }
+    }
+}
+
+impl ModelProvider for GoProxyProvider {
+    fn chat(&self, prompt: String) -> ReceiverStream<ChatChunk> {
+        let (tx, rx) = mpsc::channel(32);
+        let this = self.clone();
+        tokio::spawn(async move {
+            this.send_request(prompt, tx).await;
+        });
+        ReceiverStream::new(rx)
+    }
+
+    fn usage(&self) -> Usage {
+        self.usage.lock().unwrap().clone()
+    }
+}

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -28,6 +28,7 @@ pub trait ModelProvider: Send + Sync {
 }
 
 pub mod anthropic;
+pub mod go_proxy;
 pub mod openai;
 
 pub mod mock {
@@ -93,6 +94,11 @@ static REGISTRY: Lazy<HashMap<&'static str, Factory>> = Lazy::new(|| {
     let mut m: HashMap<&'static str, Factory> = HashMap::new();
     m.insert("mock", || Box::new(mock::MockProvider::default()));
     m.insert("mock2", || Box::new(mock::MockProvider::default()));
+    m.insert("go-proxy", || {
+        Box::new(go_proxy::GoProxyProvider::new(
+            go_proxy::GoProxyConfig::from_env(),
+        ))
+    });
     m
 });
 


### PR DESCRIPTION
## Summary
- add minimal Go bridge service exposing `/complete` and `/health` with per-model rate limits
- implement GoProxyProvider in Rust to forward requests and parse stream output
- register `go-proxy` provider via `GO_PROXY_URL`

## Testing
- `go test ./...` in `aider-go-bridge` (no test files)
- `cargo test -p aider-llm`


------
https://chatgpt.com/codex/tasks/task_b_68a43d30f93c8329a28ac866d513d04c