### PR TITLE
feat(llm): port python llm helpers to rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,7 @@ name = "aider-llm"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "dirs",
  "once_cell",
  "reqwest",
  "serde",
@@ -1090,6 +1091,15 @@ name = "directories"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
  "dirs-sys",
 ]

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -11,4 +11,5 @@ serde_json = "1"
 reqwest = { workspace = true }
 once_cell = "1"
 bytes = "1"
+dirs = "5"
 

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -29,7 +29,12 @@ pub trait ModelProvider: Send + Sync {
 
 pub mod anthropic;
 pub mod go_proxy;
+pub mod llm;
+pub mod models;
 pub mod openai;
+pub mod openrouter;
+pub mod sendchat;
+pub mod urls;
 
 pub mod mock {
     use super::*;

--- a/crates/llm/src/llm.rs
+++ b/crates/llm/src/llm.rs
@@ -1,0 +1,13 @@
+use once_cell::sync::Lazy;
+use reqwest::Client;
+
+pub const AIDER_SITE_URL: &str = "https://aider.chat";
+pub const AIDER_APP_NAME: &str = "Aider";
+
+/// Lazily initialized HTTP client used for LLM requests.
+pub static CLIENT: Lazy<Client> = Lazy::new(|| {
+    Client::builder()
+        .user_agent(AIDER_APP_NAME)
+        .build()
+        .expect("failed to build reqwest client")
+});

--- a/crates/llm/src/models.rs
+++ b/crates/llm/src/models.rs
@@ -1,0 +1,138 @@
+use crate::openrouter::OpenRouterModelManager;
+use serde_json::Value;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
+
+pub struct ModelInfoManager {
+    cache_dir: PathBuf,
+    cache_file: PathBuf,
+    content: Option<Value>,
+    verify_ssl: bool,
+    cache_loaded: bool,
+    pub(crate) openrouter_manager: OpenRouterModelManager,
+}
+
+impl ModelInfoManager {
+    const MODEL_INFO_URL: &'static str = "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+    const CACHE_TTL: Duration = Duration::from_secs(60 * 60 * 24);
+
+    pub fn new() -> Self {
+        let cache_dir = dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".aider")
+            .join("caches");
+        let cache_file = cache_dir.join("model_prices_and_context_window.json");
+        Self {
+            cache_dir,
+            cache_file,
+            content: None,
+            verify_ssl: true,
+            cache_loaded: false,
+            openrouter_manager: OpenRouterModelManager::new(),
+        }
+    }
+
+    pub fn set_verify_ssl(&mut self, verify: bool) {
+        self.verify_ssl = verify;
+        self.openrouter_manager.set_verify_ssl(verify);
+    }
+
+    /// Create a manager with a custom OpenRouter manager (useful for tests).
+    pub fn with_openrouter_manager(openrouter: OpenRouterModelManager) -> Self {
+        let mut mgr = Self::new();
+        mgr.openrouter_manager = openrouter;
+        mgr
+    }
+
+    /// Override the cached content (primarily for tests).
+    pub fn set_content(&mut self, content: Value) {
+        self.content = Some(content);
+        self.cache_loaded = true;
+    }
+
+    pub async fn get_model_info(&mut self, model: &str) -> Value {
+        self.ensure_content().await;
+        if let Some(content) = &self.content {
+            if let Some(info) = content.get(model) {
+                return info.clone();
+            }
+            if let Some((provider, name)) = model.split_once('/') {
+                if let Some(info) = content.get(name) {
+                    if info.get("litellm_provider").and_then(|v| v.as_str()) == Some(provider) {
+                        return info.clone();
+                    }
+                }
+            }
+        }
+        if model.starts_with("openrouter/") {
+            if let Some(info) = self.openrouter_manager.get_model_info(model).await {
+                return info;
+            }
+        }
+        Value::Null
+    }
+
+    async fn ensure_content(&mut self) {
+        if !self.cache_loaded {
+            self.load_cache();
+        }
+        if self.content.is_none() {
+            self.update_cache().await;
+        }
+    }
+
+    fn load_cache(&mut self) {
+        if self.cache_loaded {
+            return;
+        }
+        if let Ok(metadata) = fs::metadata(&self.cache_file) {
+            if let Ok(modified) = metadata.modified() {
+                if let Ok(age) = SystemTime::now().duration_since(modified) {
+                    if age < Self::CACHE_TTL {
+                        if let Ok(text) = fs::read_to_string(&self.cache_file) {
+                            if let Ok(json) = serde_json::from_str(&text) {
+                                self.content = Some(json);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        self.cache_loaded = true;
+    }
+
+    async fn update_cache(&mut self) {
+        let client = reqwest::Client::builder()
+            .danger_accept_invalid_certs(!self.verify_ssl)
+            .build()
+            .expect("build client");
+        if let Ok(resp) = client.get(Self::MODEL_INFO_URL).send().await {
+            if resp.status().is_success() {
+                if let Ok(json) = resp.json::<Value>().await {
+                    self.content = Some(json.clone());
+                    let _ = fs::create_dir_all(&self.cache_dir);
+                    let _ = fs::write(
+                        &self.cache_file,
+                        serde_json::to_string_pretty(&json).unwrap(),
+                    );
+                }
+            }
+        }
+    }
+}
+
+pub struct Model {
+    pub name: String,
+    pub info: Value,
+}
+
+impl Model {
+    pub async fn new(name: &str, manager: &mut ModelInfoManager) -> Self {
+        let info = manager.get_model_info(name).await;
+        Self {
+            name: name.to_string(),
+            info,
+        }
+    }
+}

--- a/crates/llm/src/openrouter.rs
+++ b/crates/llm/src/openrouter.rs
@@ -1,0 +1,141 @@
+use serde_json::{json, Value};
+use std::fs;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
+
+fn cost_per_token(val: Option<&str>) -> Option<f64> {
+    match val {
+        Some("0") => Some(0.0),
+        Some(v) => v.parse().ok(),
+        None => None,
+    }
+}
+
+pub struct OpenRouterModelManager {
+    cache_dir: PathBuf,
+    cache_file: PathBuf,
+    pub(crate) content: Option<Value>,
+    verify_ssl: bool,
+    cache_loaded: bool,
+}
+
+impl OpenRouterModelManager {
+    const MODELS_URL: &'static str = "https://openrouter.ai/api/v1/models";
+    const CACHE_TTL: Duration = Duration::from_secs(60 * 60 * 24);
+
+    pub fn new() -> Self {
+        let cache_dir = dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".aider")
+            .join("caches");
+        let cache_file = cache_dir.join("openrouter_models.json");
+        Self {
+            cache_dir,
+            cache_file,
+            content: None,
+            verify_ssl: true,
+            cache_loaded: false,
+        }
+    }
+
+    pub fn set_verify_ssl(&mut self, verify: bool) {
+        self.verify_ssl = verify;
+    }
+
+    /// Create a manager with predefined content (useful for tests).
+    pub fn with_content(content: Value) -> Self {
+        let mut mgr = Self::new();
+        mgr.content = Some(content);
+        mgr.cache_loaded = true;
+        mgr
+    }
+
+    pub async fn get_model_info(&mut self, model: &str) -> Option<Value> {
+        self.ensure_content().await;
+        let content = self.content.as_ref()?;
+        let route = self.strip_prefix(model);
+        let mut candidates = vec![route.to_string()];
+        if let Some((base, _)) = route.split_once(':') {
+            candidates.push(base.to_string());
+        }
+        let data = content.get("data")?.as_array()?;
+        let record = data.iter().find(|item| {
+            item.get("id")
+                .and_then(|v| v.as_str())
+                .map(|id| candidates.iter().any(|c| c == id))
+                .unwrap_or(false)
+        })?;
+        let context_len = record
+            .get("top_provider")
+            .and_then(|tp| tp.get("context_length"))
+            .or_else(|| record.get("context_length"))
+            .and_then(|v| v.as_u64());
+        let pricing = record
+            .get("pricing")
+            .and_then(|v| v.as_object())
+            .cloned()
+            .unwrap_or_default();
+        let prompt = pricing.get("prompt").and_then(|v| v.as_str());
+        let completion = pricing.get("completion").and_then(|v| v.as_str());
+        Some(json!({
+            "max_input_tokens": context_len,
+            "max_tokens": context_len,
+            "max_output_tokens": context_len,
+            "input_cost_per_token": cost_per_token(prompt),
+            "output_cost_per_token": cost_per_token(completion),
+            "litellm_provider": "openrouter",
+        }))
+    }
+
+    fn strip_prefix<'a>(&self, model: &'a str) -> &'a str {
+        model.strip_prefix("openrouter/").unwrap_or(model)
+    }
+
+    async fn ensure_content(&mut self) {
+        if !self.cache_loaded {
+            self.load_cache();
+        }
+        if self.content.is_none() {
+            self.update_cache().await;
+        }
+    }
+
+    fn load_cache(&mut self) {
+        if self.cache_loaded {
+            return;
+        }
+        if let Ok(metadata) = fs::metadata(&self.cache_file) {
+            if let Ok(modified) = metadata.modified() {
+                if let Ok(age) = SystemTime::now().duration_since(modified) {
+                    if age < Self::CACHE_TTL {
+                        if let Ok(text) = fs::read_to_string(&self.cache_file) {
+                            if let Ok(json) = serde_json::from_str(&text) {
+                                self.content = Some(json);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        self.cache_loaded = true;
+    }
+
+    async fn update_cache(&mut self) {
+        let client = reqwest::Client::builder()
+            .danger_accept_invalid_certs(!self.verify_ssl)
+            .build()
+            .expect("build client");
+        if let Ok(resp) = client.get(Self::MODELS_URL).send().await {
+            if resp.status().is_success() {
+                if let Ok(json) = resp.json::<Value>().await {
+                    self.content = Some(json.clone());
+                    let _ = fs::create_dir_all(&self.cache_dir);
+                    let _ = fs::write(
+                        &self.cache_file,
+                        serde_json::to_string_pretty(&json).unwrap(),
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/llm/src/sendchat.rs
+++ b/crates/llm/src/sendchat.rs
@@ -1,0 +1,64 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Message {
+    pub role: String,
+    pub content: String,
+}
+
+/// Check that messages alternate between user and assistant and the last
+/// non-system message is from the user.
+pub fn sanity_check_messages(messages: &[Message]) -> Result<(), String> {
+    let mut last_role: Option<&str> = None;
+    let mut last_non_system: Option<&str> = None;
+
+    for msg in messages {
+        let role = msg.role.as_str();
+        if role == "system" {
+            continue;
+        }
+        if let Some(prev) = last_role {
+            if role == prev {
+                return Err("Messages don't properly alternate user/assistant".into());
+            }
+        }
+        last_role = Some(role);
+        last_non_system = Some(role);
+    }
+
+    match last_non_system {
+        Some("user") => Ok(()),
+        _ => Err("Last non-system message must be from user".into()),
+    }
+}
+
+/// Ensure messages alternate between assistant and user roles by inserting
+/// empty messages of the opposite role when needed.
+pub fn ensure_alternating_roles(messages: &[Message]) -> Vec<Message> {
+    if messages.is_empty() {
+        return Vec::new();
+    }
+    let mut fixed = Vec::new();
+    let mut prev_role: Option<&str> = None;
+
+    for msg in messages {
+        let current = msg.role.as_str();
+        if let Some(prev) = prev_role {
+            if current == prev {
+                let opposite = if current == "user" {
+                    "assistant"
+                } else {
+                    "user"
+                };
+                fixed.push(Message {
+                    role: opposite.to_string(),
+                    content: String::new(),
+                });
+            }
+        }
+        fixed.push(msg.clone());
+        prev_role = Some(current);
+    }
+
+    fixed
+}

--- a/crates/llm/src/urls.rs
+++ b/crates/llm/src/urls.rs
@@ -1,0 +1,20 @@
+pub const WEBSITE: &str = "https://aider.chat/";
+pub const ADD_ALL_FILES: &str =
+    "https://aider.chat/docs/faq.html#how-can-i-add-all-the-files-to-the-chat";
+pub const EDIT_ERRORS: &str = "https://aider.chat/docs/troubleshooting/edit-errors.html";
+pub const GIT: &str = "https://aider.chat/docs/git.html";
+pub const ENABLE_PLAYWRIGHT: &str =
+    "https://aider.chat/docs/install/optional.html#enable-playwright";
+pub const FAVICON: &str = "https://aider.chat/assets/icons/favicon-32x32.png";
+pub const MODEL_WARNINGS: &str = "https://aider.chat/docs/llms/warnings.html";
+pub const TOKEN_LIMITS: &str = "https://aider.chat/docs/troubleshooting/token-limits.html";
+pub const LLMS: &str = "https://aider.chat/docs/llms.html";
+pub const LARGE_REPOS: &str =
+    "https://aider.chat/docs/faq.html#can-i-use-aider-in-a-large-mono-repo";
+pub const GITHUB_ISSUES: &str = "https://github.com/Aider-AI/aider/issues/new";
+pub const GIT_INDEX_VERSION: &str = "https://github.com/Aider-AI/aider/issues/211";
+pub const INSTALL_PROPERLY: &str = "https://aider.chat/docs/troubleshooting/imports.html";
+pub const ANALYTICS: &str = "https://aider.chat/docs/more/analytics.html";
+pub const RELEASE_NOTES: &str = "https://aider.chat/HISTORY.html#release-notes";
+pub const EDIT_FORMATS: &str = "https://aider.chat/docs/more/edit-formats.html";
+pub const MODELS_AND_KEYS: &str = "https://aider.chat/docs/troubleshooting/models-and-keys.html";

--- a/crates/llm/tests/models.rs
+++ b/crates/llm/tests/models.rs
@@ -1,0 +1,27 @@
+use aider_llm::models::ModelInfoManager;
+use aider_llm::openrouter::OpenRouterModelManager;
+use serde_json::json;
+
+#[tokio::test]
+async fn openrouter_model_info_from_cache() {
+    let content = json!({
+        "data": [{
+            "id": "a/b",
+            "context_length": 100,
+            "pricing": {"prompt": "0.1", "completion": "0.2"}
+        }]
+    });
+    let or = OpenRouterModelManager::with_content(content);
+    let mut mgr = ModelInfoManager::with_openrouter_manager(or);
+    let info = mgr.get_model_info("openrouter/a/b").await;
+    assert_eq!(info.get("max_tokens").and_then(|v| v.as_u64()), Some(100));
+    assert_eq!(
+        info.get("litellm_provider").and_then(|v| v.as_str()),
+        Some("openrouter")
+    );
+}
+
+#[test]
+fn urls_constant() {
+    assert_eq!(aider_llm::urls::WEBSITE, "https://aider.chat/");
+}

--- a/crates/llm/tests/sendchat.rs
+++ b/crates/llm/tests/sendchat.rs
@@ -1,0 +1,53 @@
+use aider_llm::sendchat::{ensure_alternating_roles, sanity_check_messages, Message};
+
+#[test]
+fn sanity_check_valid() {
+    let msgs = vec![
+        Message {
+            role: "user".into(),
+            content: "hi".into(),
+        },
+        Message {
+            role: "assistant".into(),
+            content: "hello".into(),
+        },
+        Message {
+            role: "user".into(),
+            content: "again".into(),
+        },
+    ];
+    assert!(sanity_check_messages(&msgs).is_ok());
+}
+
+#[test]
+fn sanity_check_invalid() {
+    let msgs = vec![
+        Message {
+            role: "user".into(),
+            content: "hi".into(),
+        },
+        Message {
+            role: "user".into(),
+            content: "again".into(),
+        },
+    ];
+    assert!(sanity_check_messages(&msgs).is_err());
+}
+
+#[test]
+fn ensure_alternating_inserts() {
+    let msgs = vec![
+        Message {
+            role: "user".into(),
+            content: "1".into(),
+        },
+        Message {
+            role: "user".into(),
+            content: "2".into(),
+        },
+    ];
+    let fixed = ensure_alternating_roles(&msgs);
+    assert_eq!(fixed.len(), 3);
+    assert_eq!(fixed[1].role, "assistant");
+    assert!(fixed[1].content.is_empty());
+}


### PR DESCRIPTION
## Summary
- mirror Python llm, openrouter, models, sendchat and URL helpers in Rust
- add async OpenRouter/model metadata fetching via reqwest
- expose safe message utilities and URL constants for Rust CLI

## Testing
- `cargo test -p aider-llm`


------
https://chatgpt.com/codex/tasks/task_b_68a795fba1a08329a5392da941bdf1e6