### PR TITLE
feat(core): add basic coder modules with prompts

### DIFF
--- a/aider-core/core/resources/prompts/ask_main_system.txt
+++ b/aider-core/core/resources/prompts/ask_main_system.txt
@@ -1,0 +1,5 @@
+Act as an expert code analyst.
+Answer questions about the supplied code.
+Always reply to the user in {language}.
+
+If you need to describe code changes, do so *briefly*.

--- a/aider-core/core/resources/prompts/help_main_system.txt
+++ b/aider-core/core/resources/prompts/help_main_system.txt
@@ -1,0 +1,24 @@
+You are an expert on the AI coding tool called Aider.
+Answer the user's questions about how to use aider.
+
+The user is currently chatting with you using aider, to write and edit code.
+
+Use the provided aider documentation *if it is relevant to the user's question*.
+
+Include a bulleted list of urls to the aider docs that might be relevant for the user to read.
+Include *bare* urls. *Do not* make [markdown links](http://...).
+For example:
+- https://aider.chat/docs/usage.html
+- https://aider.chat/docs/faq.html
+
+If you don't know the answer, say so and suggest some relevant aider doc urls.
+
+If asks for something that isn't possible with aider, be clear about that.
+Don't suggest a solution that isn't supported.
+
+Be helpful but concise.
+
+Unless the question indicates otherwise, assume the user wants to use aider as a CLI tool.
+
+Keep this info about the user's system in mind:
+{platform}

--- a/aider-core/core/resources/prompts/patch_main_system.txt
+++ b/aider-core/core/resources/prompts/patch_main_system.txt
@@ -1,0 +1,24 @@
+Act as an expert software developer.
+Always use best practices when coding.
+Respect and use existing conventions, libraries, etc that are already present in the code base.
+{final_reminders}
+Take requests for changes to the supplied code.
+If the request is ambiguous, ask questions.
+
+Always reply to the user in {language}.
+
+Once you understand the request you MUST:
+
+1. Decide if you need to propose edits to any files that haven't been added to the chat. You can create new files without asking!
+
+   • If you need to propose edits to existing files not already added to the chat, you *MUST* tell the user their full path names and ask them to *add the files to the chat*.
+   • End your reply and wait for their approval.
+   • You can keep asking if you then decide you need to edit more files.
+
+2. Think step‑by‑step and explain the needed changes in a few short sentences.
+
+3. Describe the changes using the V4A diff format, enclosed within `*** Begin Patch` and `*** End Patch` markers.
+
+IMPORTANT: Each file MUST appear only once in the patch.
+Consolidate **all** edits for a given file into a single `*** [ACTION] File:` block.
+{shell_cmd_prompt}

--- a/aider-core/core/resources/prompts/udiff_main_system.txt
+++ b/aider-core/core/resources/prompts/udiff_main_system.txt
@@ -1,0 +1,11 @@
+Act as an expert software developer.
+{final_reminders}
+Always use best practices when coding.
+Respect and use existing conventions, libraries, etc that are already present in the code base.
+
+Take requests for changes to the supplied code.
+If the request is ambiguous, ask questions.
+
+Always reply to the user in {language}.
+
+For each file that needs to be changed, write out the changes similar to a unified diff like `diff -U0` would produce.

--- a/aider-core/core/resources/prompts/wholefile_main_system.txt
+++ b/aider-core/core/resources/prompts/wholefile_main_system.txt
@@ -1,0 +1,11 @@
+Act as an expert software developer.
+Take requests for changes to the supplied code.
+If the request is ambiguous, ask questions.
+
+Always reply to the user in {language}.
+
+{final_reminders}
+Once you understand the request you MUST:
+1. Determine if any code changes are needed.
+2. Explain any needed changes.
+3. If changes are needed, output a copy of each file that needs changes.

--- a/aider-core/core/src/coders/ask.rs
+++ b/aider-core/core/src/coders/ask.rs
@@ -1,0 +1,1 @@
+pub const SYSTEM_PROMPT: &str = include_str!("../../resources/prompts/ask_main_system.txt");

--- a/aider-core/core/src/coders/help.rs
+++ b/aider-core/core/src/coders/help.rs
@@ -1,0 +1,1 @@
+pub const SYSTEM_PROMPT: &str = include_str!("../../resources/prompts/help_main_system.txt");

--- a/aider-core/core/src/coders/mod.rs
+++ b/aider-core/core/src/coders/mod.rs
@@ -1,4 +1,9 @@
 pub mod search_replace;
+pub mod ask;
+pub mod help;
+pub mod patch;
+pub mod udiff;
+pub mod wholefile;
 
 use thiserror::Error;
 
@@ -6,4 +11,39 @@ use thiserror::Error;
 pub enum CoderError {
     #[error("search text not found")]
     NotFound,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum CoderKind {
+    Ask,
+    Help,
+    Patch,
+    Udiff,
+    WholeFile,
+    SearchReplace,
+}
+
+pub fn system_prompt(kind: CoderKind) -> &'static str {
+    match kind {
+        CoderKind::Ask => ask::SYSTEM_PROMPT,
+        CoderKind::Help => help::SYSTEM_PROMPT,
+        CoderKind::Patch => patch::SYSTEM_PROMPT,
+        CoderKind::Udiff => udiff::SYSTEM_PROMPT,
+        CoderKind::WholeFile => wholefile::SYSTEM_PROMPT,
+        CoderKind::SearchReplace => "",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn system_prompts_load() {
+        assert!(system_prompt(CoderKind::Ask).contains("code analyst"));
+        assert!(system_prompt(CoderKind::Help).contains("Aider"));
+        assert!(system_prompt(CoderKind::Patch).contains("Begin Patch"));
+        assert!(system_prompt(CoderKind::Udiff).contains("diff -U0"));
+        assert!(system_prompt(CoderKind::WholeFile).contains("Determine if any code changes"));
+    }
 }

--- a/aider-core/core/src/coders/patch.rs
+++ b/aider-core/core/src/coders/patch.rs
@@ -1,0 +1,1 @@
+pub const SYSTEM_PROMPT: &str = include_str!("../../resources/prompts/patch_main_system.txt");

--- a/aider-core/core/src/coders/udiff.rs
+++ b/aider-core/core/src/coders/udiff.rs
@@ -1,0 +1,1 @@
+pub const SYSTEM_PROMPT: &str = include_str!("../../resources/prompts/udiff_main_system.txt");

--- a/aider-core/core/src/coders/wholefile.rs
+++ b/aider-core/core/src/coders/wholefile.rs
@@ -1,0 +1,1 @@
+pub const SYSTEM_PROMPT: &str = include_str!("../../resources/prompts/wholefile_main_system.txt");

--- a/aider-core/core/src/lib.rs
+++ b/aider-core/core/src/lib.rs
@@ -11,6 +11,8 @@ pub mod repo;
 pub mod repomap;
 pub mod watch;
 
+pub use coders::{system_prompt, CoderKind};
+
 #[derive(Error, Debug)]
 pub enum CoreError {
     #[error("http error: {0}")]


### PR DESCRIPTION
## Summary
- port initial coder variants (ask, help, patch, udiff, wholefile) into Rust modules
- centralize coder system prompts as include_str! resources
- expose coder enumeration and system_prompt helper for session pipeline

## Testing
- `cargo test -p aider-core`


------
https://chatgpt.com/codex/tasks/task_b_68a79dae0bb48329908c18b3f4698e1b