### PR TITLE
feat(core): add diff utilities and watch prompts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,7 @@ dependencies = [
  "scraper",
  "serde",
  "serde_yaml",
+ "similar",
  "tempfile",
  "tera",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tree-sitter-rust = "0.20"
 tree-sitter-go = "0.20"
 tree-sitter-python = "0.20"
 diffy = "0.3"
+similar = "2"
 tera = "1.19"
 axum = { version = "0.7", features = ["ws"] }
 tonic = { version = "0.10", features = ["transport"] }

--- a/aider-cli/Cargo.lock
+++ b/aider-cli/Cargo.lock
@@ -59,6 +59,7 @@ name = "aider-llm"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "dirs",
  "once_cell",
  "reqwest",
  "serde",
@@ -423,6 +424,15 @@ name = "directories"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
  "dirs-sys",
 ]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -24,6 +24,7 @@ tree-sitter-rust = { workspace = true }
 tree-sitter-go = { workspace = true }
 tree-sitter-python = { workspace = true }
 diffy = { workspace = true }
+similar = { workspace = true }
 tera = { workspace = true }
 axum = { workspace = true }
 tonic = { workspace = true }

--- a/crates/core/src/copypaste.rs
+++ b/crates/core/src/copypaste.rs
@@ -1,0 +1,61 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+/// Watches a clipboard-like source for changes and triggers a callback when
+/// new content is detected.
+pub struct ClipboardWatcher<F>
+where
+    F: Fn() -> Option<String> + Send + Sync + 'static,
+{
+    getter: Arc<F>,
+    stop: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+    interval: Duration,
+}
+
+impl<F> ClipboardWatcher<F>
+where
+    F: Fn() -> Option<String> + Send + Sync + 'static,
+{
+    /// Create a new watcher with the provided clipboard getter function.
+    pub fn new(getter: F) -> Self {
+        Self {
+            getter: Arc::new(getter),
+            stop: Arc::new(AtomicBool::new(false)),
+            handle: None,
+            interval: Duration::from_millis(500),
+        }
+    }
+
+    /// Start watching the clipboard and invoke `callback` on changes.
+    pub fn start<C>(&mut self, mut callback: C)
+    where
+        C: FnMut(String) + Send + 'static,
+    {
+        let getter = self.getter.clone();
+        let stop = self.stop.clone();
+        let interval = self.interval;
+        self.handle = Some(thread::spawn(move || {
+            let mut last: Option<String> = None;
+            while !stop.load(Ordering::SeqCst) {
+                if let Some(current) = getter() {
+                    if last.as_ref().map_or(true, |l| *l != current) {
+                        callback(current.clone());
+                        last = Some(current);
+                    }
+                }
+                thread::sleep(interval);
+            }
+        }));
+    }
+
+    /// Stop watching the clipboard.
+    pub fn stop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}

--- a/crates/core/src/diffs.rs
+++ b/crates/core/src/diffs.rs
@@ -1,0 +1,125 @@
+use diffy::create_patch;
+use similar::{ChangeTag, TextDiff};
+
+/// Create a progress bar string for the given percentage.
+fn create_progress_bar(percentage: usize) -> String {
+    const TOTAL: usize = 30;
+    let filled = TOTAL * percentage / 100;
+    let empty = TOTAL - filled;
+    let block = "█".repeat(filled);
+    let empty = "░".repeat(empty);
+    format!("{block}{empty}")
+}
+
+fn assert_newlines(lines: &[String]) {
+    if lines.is_empty() {
+        return;
+    }
+    for line in &lines[..lines.len() - 1] {
+        assert!(line.ends_with('\n'), "missing newline");
+    }
+}
+
+fn find_last_non_deleted(lines_orig: &[String], lines_updated: &[String]) -> Option<usize> {
+    let orig = lines_orig.join("");
+    let updated = lines_updated.join("");
+    let diff = TextDiff::from_lines(&orig, &updated);
+    let mut num_orig = 0usize;
+    let mut last = None;
+    for change in diff.iter_all_changes() {
+        match change.tag() {
+            ChangeTag::Equal => {
+                num_orig += 1;
+                last = Some(num_orig);
+            }
+            ChangeTag::Delete => {
+                num_orig += 1;
+            }
+            ChangeTag::Insert => {}
+        }
+    }
+    last
+}
+
+/// Generate a unified diff for a partial update.
+///
+/// This mirrors the behavior of the Python implementation in `aider/diffs.py`.
+/// When `final_update` is false, deleted lines beyond the last updated line are
+/// ignored and a progress bar is inserted to indicate the amount of work
+/// completed.
+pub fn diff_partial_update(
+    lines_orig: &[String],
+    lines_updated: &[String],
+    final_update: bool,
+    fname: Option<&str>,
+) -> String {
+    assert_newlines(lines_orig);
+    let num_orig_lines = lines_orig.len();
+
+    let last_non_deleted = if final_update {
+        num_orig_lines
+    } else {
+        match find_last_non_deleted(lines_orig, lines_updated) {
+            Some(n) => n,
+            None => return String::new(),
+        }
+    };
+
+    let pct = if num_orig_lines > 0 {
+        last_non_deleted * 100 / num_orig_lines
+    } else {
+        50
+    };
+    let bar = create_progress_bar(pct);
+    let bar_line = format!(" {last_non_deleted:3} / {num_orig_lines:3} lines [{bar}] {pct:3}%\n");
+
+    let orig_prefix = lines_orig[..last_non_deleted].join("");
+    let mut updated_lines = lines_updated.to_vec();
+    if !final_update {
+        if !updated_lines.is_empty() {
+            updated_lines.pop();
+        }
+        updated_lines.push(bar_line.clone());
+    }
+    let updated_text = updated_lines.join("");
+
+    let patch = create_patch(&orig_prefix, &updated_text);
+    let mut diff = patch.to_string();
+    if !diff.ends_with('\n') {
+        diff.push('\n');
+    }
+
+    let mut ticks = 3usize;
+    while diff.contains(&"`".repeat(ticks)) && ticks < 10 {
+        ticks += 1;
+    }
+    let fence = "`".repeat(ticks);
+    let mut show = format!("{fence}diff\n");
+    if let Some(name) = fname {
+        show.push_str(&format!("--- {name} original\n+++ {name} updated\n"));
+    }
+    show.push_str(&diff);
+    show.push_str(&format!("{fence}\n\n"));
+    show
+}
+
+/// Generate a unified diff for two complete texts.
+pub fn unified_diff(orig: &str, updated: &str, fname: Option<&str>) -> String {
+    let patch = create_patch(orig, updated);
+    let mut diff = patch.to_string();
+    if !diff.ends_with('\n') {
+        diff.push('\n');
+    }
+    let mut ticks = 3usize;
+    while diff.contains(&"`".repeat(ticks)) && ticks < 10 {
+        ticks += 1;
+    }
+    let fence = "`".repeat(ticks);
+    let mut out = format!("{fence}diff\n");
+    if let Some(name) = fname {
+        out.push_str(&format!("--- {name} original\n+++ {name} updated\n"));
+    }
+    out.push_str(&diff);
+    out.push_str(&format!("{fence}\n\n"));
+    out
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -4,6 +4,8 @@ use tracing_subscriber::FmtSubscriber;
 
 pub mod command;
 pub mod commit;
+pub mod copypaste;
+pub mod diffs;
 pub mod edit;
 pub mod git;
 pub mod runner;
@@ -11,15 +13,19 @@ pub mod session;
 pub mod url;
 pub mod voice;
 pub mod watch;
+pub mod watch_prompts;
 pub use aider_llm::{mock::MockProvider, ModelProvider};
 pub use command::Command;
 pub use commit::generate_commit_message;
+pub use copypaste::ClipboardWatcher;
+pub use diffs::{diff_partial_update, unified_diff};
 pub use edit::{apply_diff_edit, apply_whole_file_edit};
 pub use git::{GitRepo, RepoStatus};
 pub use runner::{apply_with_runner, CommandResult, JsRunner, RunOptions, Runner, RustRunner};
 pub use session::{Mode, Session};
 pub use voice::VoiceTranscriber;
 pub use watch::FileWatcher;
+pub use watch_prompts::{watch_ask_prompt, watch_code_prompt};
 
 pub fn init_tracing() -> Result<()> {
     let subscriber = FmtSubscriber::new();

--- a/crates/core/src/watch_prompts.rs
+++ b/crates/core/src/watch_prompts.rs
@@ -1,0 +1,15 @@
+/// Prompt displayed when watch mode detects code comments with `AI` markers.
+pub const WATCH_CODE_PROMPT: &str = "I've written your instructions in comments in the code and marked them with \"ai\"\nYou can see the \"AI\" comments shown below (marked with █).\nFind them in the code files I've shared with you, and follow their instructions.\n\nAfter completing those instructions, also be sure to remove all the \"AI\" comments from the code too.";
+
+/// Prompt displayed when watch mode detects `/ask` comments.
+pub const WATCH_ASK_PROMPT: &str = "/ask\nFind the \"AI\" comments below (marked with █) in the code files I've shared with you.\nThey contain my questions that I need you to answer and other instructions for you.";
+
+/// Return the watch code prompt.
+pub fn watch_code_prompt() -> &'static str {
+    WATCH_CODE_PROMPT
+}
+
+/// Return the watch ask prompt.
+pub fn watch_ask_prompt() -> &'static str {
+    WATCH_ASK_PROMPT
+}

--- a/crates/core/tests/diffs.rs
+++ b/crates/core/tests/diffs.rs
@@ -1,0 +1,11 @@
+use aider_core::unified_diff;
+
+#[test]
+fn unified_diff_shows_changes() {
+    let orig = "old\n";
+    let updated = "new\n";
+    let diff = unified_diff(orig, updated, Some("file.txt"));
+    assert!(diff.contains("-old"));
+    assert!(diff.contains("+new"));
+    assert!(diff.contains("file.txt"));
+}

--- a/crates/core/tests/git_diff.rs
+++ b/crates/core/tests/git_diff.rs
@@ -1,0 +1,20 @@
+use std::fs;
+
+use aider_core::GitRepo;
+use git2::Repository;
+use tempfile::tempdir;
+
+#[test]
+fn detects_file_change_with_git() {
+    let dir = tempdir().unwrap();
+    Repository::init(dir.path()).unwrap();
+    let git = GitRepo::open(dir.path()).unwrap();
+    let file = dir.path().join("file.txt");
+    fs::write(&file, "old\n").unwrap();
+    git.stage("file.txt").unwrap();
+    git.commit("init").unwrap();
+    fs::write(&file, "new\n").unwrap();
+    let diff = git.diff_unstaged().unwrap();
+    assert!(diff.contains("-old"));
+    assert!(diff.contains("+new"));
+}

--- a/crates/core/tests/prompts.rs
+++ b/crates/core/tests/prompts.rs
@@ -1,0 +1,13 @@
+use aider_core::{watch_ask_prompt, watch_code_prompt};
+
+#[test]
+fn code_prompt_contains_instructions() {
+    let prompt = watch_code_prompt();
+    assert!(prompt.contains("I've written your instructions"));
+}
+
+#[test]
+fn ask_prompt_starts_with_slash() {
+    let prompt = watch_ask_prompt();
+    assert!(prompt.starts_with("/ask"));
+}


### PR DESCRIPTION
## Summary
- add Rust diff utilities for partial and unified diffs
- implement clipboard watcher abstraction
- provide watch-mode code and ask prompts
- test diff generation, git change detection, and prompt assembly

## Testing
- `cargo test -p aider-core`


------
https://chatgpt.com/codex/tasks/task_b_68a7c05549e483298c4080a5dbd83369