### PR TITLE
feat: port prompts and reasoning helpers to Rust

### DIFF
--- a/aider-cli/Cargo.lock
+++ b/aider-cli/Cargo.lock
@@ -37,6 +37,7 @@ dependencies = [
  "clap",
  "ignore",
  "notify",
+ "regex",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/aider-cli/Cargo.toml
+++ b/aider-cli/Cargo.toml
@@ -25,6 +25,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter", "json"] }
 aider-llm = { path = "../crates/llm" }
 aider-utils = { path = "../crates/utils" }
+regex = "1"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/aider-cli/src/commands.rs
+++ b/aider-cli/src/commands.rs
@@ -1,0 +1,33 @@
+/// Determine whether the given input line is a special slash command.
+/// Currently treats lines starting with '/' or '!' as special commands.
+pub fn is_special_command(line: &str) -> bool {
+    matches!(line.chars().next(), Some('/') | Some('!'))
+}
+
+/// Extract the command name from a special command line, without the prefix.
+/// Returns `None` if the line is not a special command.
+pub fn extract_command(line: &str) -> Option<&str> {
+    if !is_special_command(line) {
+        return None;
+    }
+    line[1..].split_whitespace().next()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_special_command() {
+        assert!(is_special_command("/ask"));
+        assert!(is_special_command("!help"));
+        assert!(!is_special_command("hello"));
+    }
+
+    #[test]
+    fn test_extract_command() {
+        assert_eq!(extract_command("/ask something"), Some("ask"));
+        assert_eq!(extract_command("!help"), Some("help"));
+        assert_eq!(extract_command("hello"), None);
+    }
+}

--- a/aider-cli/src/help_patterns.rs
+++ b/aider-cli/src/help_patterns.rs
@@ -1,0 +1,29 @@
+/// Patterns of files to exclude when bundling website help content.
+/// Ported from the Python `help_pats.py` module.
+pub const EXCLUDE_WEBSITE_PATS: &[&str] = &[
+    "**/.DS_Store",
+    "examples/**",
+    "_posts/**",
+    "HISTORY.md",
+    "docs/benchmarks*md",
+    "docs/ctags.md",
+    "docs/unified-diffs.md",
+    "docs/leaderboards/index.md",
+    "assets/**",
+    ".jekyll-metadata",
+    "Gemfile.lock",
+    "Gemfile",
+    "_config.yml",
+    "**/OLD/**",
+    "OLD/**",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn patterns_include_known_entry() {
+        assert!(EXCLUDE_WEBSITE_PATS.contains(&"HISTORY.md"));
+    }
+}

--- a/aider-cli/src/lib.rs
+++ b/aider-cli/src/lib.rs
@@ -1,1 +1,5 @@
+pub mod commands;
+pub mod help_patterns;
+pub mod prompts;
+pub mod reasoning;
 pub mod usage;

--- a/aider-cli/src/main.rs
+++ b/aider-cli/src/main.rs
@@ -1,7 +1,10 @@
 mod analytics;
 mod args;
+mod commands;
+mod help_patterns;
 mod history;
 mod prompts;
+mod reasoning;
 mod repo;
 mod repomap;
 mod resources;
@@ -97,6 +100,14 @@ fn run() -> Result<()> {
             })
         );
     }
+
+    // Demonstrate special command detection and reasoning tag handling.
+    if commands::is_special_command("/ask how are you?") {
+        info!("special command detected");
+    }
+    let cleaned = reasoning::remove_reasoning_content("<tag>secret</tag> answer", Some("tag"));
+    info!(%cleaned, "reasoning cleaned");
+    info!(patterns = help_patterns::EXCLUDE_WEBSITE_PATS.len(), "loaded help patterns");
 
     // Start file watching in the background.
     let _watcher = watch::watch(&std::env::current_dir()?)?;

--- a/aider-cli/src/prompts.rs
+++ b/aider-cli/src/prompts.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use serde::Serialize;
 use tera::{Context, Tera};
 
 /// Template handling using `tera`, replacing the Python `prompts.py` module.
@@ -19,8 +20,20 @@ impl Prompts {
         Ok(self.tera.render(name, ctx)?)
     }
 
+    /// Render a named template using any serializable data as context.
+    pub fn render_with<T: Serialize>(&self, name: &str, data: &T) -> Result<String> {
+        let ctx = Context::from_serialize(data)?;
+        self.render(name, &ctx)
+    }
+
     /// Render a raw template string with the supplied context.
     pub fn render_str(&mut self, template: &str, ctx: &Context) -> Result<String> {
         Ok(self.tera.render_str(template, ctx)?)
+    }
+
+    /// Render a raw template string using any serializable data.
+    pub fn render_str_with<T: Serialize>(&mut self, template: &str, data: &T) -> Result<String> {
+        let ctx = Context::from_serialize(data)?;
+        self.render_str(template, &ctx)
     }
 }

--- a/aider-cli/src/reasoning.rs
+++ b/aider-cli/src/reasoning.rs
@@ -1,0 +1,69 @@
+use regex::Regex;
+
+/// Standard reasoning tag identifier.
+pub const REASONING_TAG: &str = "thinking-content-7bbeb8e1441453ad999a0bbba8a46d4b";
+
+/// Markers used when rendering reasoning content for display.
+pub const REASONING_START: &str = "--------------\n► **THINKING**";
+pub const REASONING_END: &str = "------------\n► **ANSWER**";
+
+/// Remove reasoning content from text based on tags.
+pub fn remove_reasoning_content(res: &str, reasoning_tag: Option<&str>) -> String {
+    if reasoning_tag.is_none() {
+        return res.to_string();
+    }
+    let tag = reasoning_tag.unwrap();
+    let pattern = Regex::new(&format!("<{}>.*?</{}>", tag, tag)).unwrap();
+    let mut res = pattern.replace_all(res, "").to_string();
+    let closing = format!("</{}>", tag);
+    if let Some(idx) = res.find(&closing) {
+        res = res[idx + closing.len()..].to_string();
+    }
+    res.trim().to_string()
+}
+
+/// Replace opening and closing reasoning tags with standard formatting.
+pub fn replace_reasoning_tags(text: &str, tag_name: &str) -> String {
+    if text.is_empty() {
+        return String::new();
+    }
+    let open = Regex::new(&format!("\\s*<{}>\\s*", tag_name)).unwrap();
+    let close = Regex::new(&format!("\\s*</{}>\\s*", tag_name)).unwrap();
+    let text = open.replace_all(text, &format!("\n{}\n\n", REASONING_START));
+    let text = close.replace_all(&text, &format!("\n\n{}\n\n", REASONING_END));
+    text.into_owned()
+}
+
+/// Format reasoning content with tags.
+pub fn format_reasoning_content(reasoning_content: &str, tag_name: &str) -> String {
+    if reasoning_content.is_empty() {
+        return String::new();
+    }
+    format!("<{}>\n\n{}\n\n</{}>", tag_name, reasoning_content, tag_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_remove_reasoning_content() {
+        let text = "<tag>secret</tag> public";
+        assert_eq!(remove_reasoning_content(text, Some("tag")), "public");
+    }
+
+    #[test]
+    fn test_replace_reasoning_tags() {
+        let text = "<tag>reasoning</tag>";
+        let replaced = replace_reasoning_tags(text, "tag");
+        assert!(replaced.contains(REASONING_START));
+        assert!(replaced.contains(REASONING_END));
+    }
+
+    #[test]
+    fn test_format_reasoning_content() {
+        let formatted = format_reasoning_content("content", "tag");
+        assert_eq!(formatted, "<tag>\n\ncontent\n\n</tag>");
+    }
+}
+

--- a/aider-cli/tests/reasoning.rs
+++ b/aider-cli/tests/reasoning.rs
@@ -1,0 +1,10 @@
+use aider_cli::reasoning::{format_reasoning_content, remove_reasoning_content, replace_reasoning_tags};
+
+#[test]
+fn reasoning_roundtrip() {
+    let tagged = format_reasoning_content("secret", "tag");
+    let replaced = replace_reasoning_tags(&tagged, "tag");
+    assert!(replaced.contains("THINKING"));
+    let cleaned = remove_reasoning_content(&tagged, Some("tag"));
+    assert_eq!(cleaned, "");
+}


### PR DESCRIPTION
## Summary
- convert help patterns and prompt rendering to Rust modules
- add reasoning tag parser and special command detection
- expose new helpers and integrate with CLI

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68a92597251083299fe55efa18f7f7ef