### PR TITLE
Add Go sidecar tests mirroring Python run_cmd checks

### DIFF
--- a/go-shell/sidecarclient/client_test.go
+++ b/go-shell/sidecarclient/client_test.go
@@ -1,0 +1,87 @@
+package sidecarclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
+)
+
+func TestRepoMap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rpc" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		var req rpcRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if req.Method != "repo.map" {
+			t.Fatalf("expected method repo.map, got %s", req.Method)
+		}
+		resp := rpcResponse{Result: json.RawMessage(`"repo data"`)}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := &Client{http: retryablehttp.NewClient(), httpURL: srv.URL}
+	out, err := c.RepoMap(context.Background())
+	if err != nil {
+		t.Fatalf("RepoMap: %v", err)
+	}
+	if out != "repo data" {
+		t.Fatalf("expected repo data, got %s", out)
+	}
+}
+
+func TestCommandEcho(t *testing.T) {
+	up := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/command" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		conn, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade: %v", err)
+		}
+		defer conn.Close()
+		if _, _, err := conn.ReadMessage(); err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if err := conn.WriteJSON(map[string]interface{}{"type": "stdout", "data": "Hello, World!\n"}); err != nil {
+			t.Fatalf("write stdout: %v", err)
+		}
+		if err := conn.WriteJSON(map[string]interface{}{"type": "exit", "code": 0}); err != nil {
+			t.Fatalf("write exit: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	c := &Client{wsURL: wsURL}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	outCh, codeCh, err := c.Command(ctx, "echo", []string{"Hello, World!"})
+	if err != nil {
+		t.Fatalf("Command: %v", err)
+	}
+	var out strings.Builder
+	for s := range outCh {
+		out.WriteString(s)
+	}
+	code := <-codeCh
+	if out.String() != "Hello, World!\n" {
+		t.Fatalf("expected output %q, got %q", "Hello, World!\n", out.String())
+	}
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+}

--- a/go_cli/main_test.go
+++ b/go_cli/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunSidecarEcho(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "cli_tui")
+	script := "#!/bin/sh\necho \"$@\"\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	oldPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", oldPath)
+	os.Setenv("PATH", dir+string(os.PathListSeparator)+oldPath)
+
+	out, err := runSidecar("Hello, World!")
+	if err != nil {
+		t.Fatalf("runSidecar returned error: %v", err)
+	}
+	expected := "--message Hello, World!\n"
+	if out != expected {
+		t.Fatalf("expected %q, got %q", expected, out)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go CLI test to ensure `runSidecar` correctly pipes command output
- add Go sidecar client tests for `RepoMap` RPC and command streaming

## Testing
- `go test ./... -run 'TestRepoMap|TestCommandEcho|TestHistoryPrompts|TestURLs' -v` in `go-shell`
- `go test ./... -v` in `go_cli`


------
https://chatgpt.com/codex/tasks/task_b_68a9b22093c88329a0ef00069743c28d