### PR TITLE
test: add Dart CLI tests

### DIFF
--- a/dart_cli/pubspec.yaml
+++ b/dart_cli/pubspec.yaml
@@ -7,6 +7,8 @@ environment:
 
 dependencies:
   args: ^2.4.2
+  dio: ^5.4.0
+  web_socket_channel: ^3.0.0
 
 dev_dependencies:
   lints: ^5.0.0

--- a/dart_cli/test/cli_test.dart
+++ b/dart_cli/test/cli_test.dart
@@ -1,0 +1,46 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+Future<Map<String, String>> _stubCliTui() async {
+  final dir = await Directory.systemTemp.createTemp();
+  final ext = Platform.isWindows ? '.bat' : '';
+  final script = File('${dir.path}/cli_tui$ext');
+  if (Platform.isWindows) {
+    await script.writeAsString('@echo off\necho %*\n');
+  } else {
+    await script.writeAsString('#!/usr/bin/env bash\necho "\$@"\n');
+    await Process.run('chmod', ['+x', script.path]);
+  }
+  final env = Map<String, String>.from(Platform.environment);
+  final sep = Platform.isWindows ? ';' : ':';
+  env['PATH'] = '${dir.path}$sep${env['PATH']}';
+  return env;
+}
+
+void main() {
+  group('dart_cli', () {
+    test('passes message to cli_tui', () async {
+      final env = await _stubCliTui();
+      const msg = 'test message';
+      final result = await Process.run(
+        'dart',
+        ['run', 'bin/dart_cli.dart', '--message', msg],
+        environment: env,
+      );
+      expect(result.exitCode, 0);
+      expect(result.stdout.toString().trim(), '--message $msg');
+    });
+
+    test('uses default message', () async {
+      final env = await _stubCliTui();
+      final result = await Process.run(
+        'dart',
+        ['run', 'bin/dart_cli.dart'],
+        environment: env,
+      );
+      expect(result.exitCode, 0);
+      expect(result.stdout.toString().trim(), '--message Hello from Dart');
+    });
+  });
+}

--- a/dart_cli/test/http_client_test.dart
+++ b/dart_cli/test/http_client_test.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+
+import 'package:dart_cli/src/http_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('performs HTTP GET request', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    server.listen((HttpRequest request) {
+      request.response
+        ..write('ok')
+        ..close();
+    });
+
+    final client = HttpClient();
+    final response = await client
+        .get<String>('http://${server.address.host}:${server.port}');
+    expect(response.data, 'ok');
+
+    await server.close(force: true);
+  });
+}


### PR DESCRIPTION
## Summary
- add dart test suite for CLI message handling
- ensure HTTP client handles basic GET requests

## Testing
- `dart test`


------
https://chatgpt.com/codex/tasks/task_b_68a9b3e38e2c83298b890781b2e70a6a