### PR TITLE
Add pytest-cov to development requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,16 @@ This repository includes a Rust workspace defined in `Cargo.toml`.
 The workspace is organized into the following crates:
 
 - `crates/core` – shared library code and common dependencies.
-- `crates/cli` – command line interface relying on the core crate.
+- `crates/cli` – command line interface relying on the core create.
 - `crates/sidecar` – placeholder for a sidecar process.
 
 The workspace targets Rust edition 2021 and is configured for
 `cargo fmt` and `cargo clippy` via `rustfmt.toml` and `clippy.toml`.
+
+## Development setup
+
+Install development dependencies to work on the project:
+
+```bash
+pip install -r requirements/requirements-dev.txt
+```

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -1,5 +1,6 @@
 pytest
 pytest-env
+pytest-cov
 pip-tools
 lox
 matplotlib

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -37,6 +37,8 @@ contourpy==1.3.3
     # via
     #   -c requirements/common-constraints.txt
     #   matplotlib
+coverage[toml]==7.10.5
+    # via pytest-cov
 cycler==0.12.1
     # via
     #   -c requirements/common-constraints.txt
@@ -184,6 +186,7 @@ pluggy==1.6.0
     # via
     #   -c requirements/common-constraints.txt
     #   pytest
+    #   pytest-cov
 pox==0.3.6
     # via
     #   -c requirements/common-constraints.txt
@@ -234,7 +237,10 @@ pytest==8.4.1
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements-dev.in
+    #   pytest-cov
     #   pytest-env
+pytest-cov==6.2.1
+    # via -r requirements/requirements-dev.in
 pytest-env==1.1.5
     # via
     #   -c requirements/common-constraints.txt


### PR DESCRIPTION
## Summary
- include pytest-cov in development requirements
- document installing dev dependencies in README

## Testing
- `pre-commit run --files requirements/requirements-dev.in requirements/requirements-dev.txt README.md`
- `pytest --maxfail=1 --disable-warnings -q --cov` *(fails: No module named 'aider.commands')*


------
https://chatgpt.com/codex/tasks/task_b_68aa6c608f848329a3b0c98db8681a6e