### PR TITLE
Add unified diff parsing and coverage checks

### DIFF
--- a/.github/workflows/multi-lang-ci.yml
+++ b/.github/workflows/multi-lang-ci.yml
@@ -21,6 +21,12 @@ jobs:
       - run: cargo fmt -- --check
       - run: cargo clippy -- -D warnings
       - run: cargo test
+      - run: cargo install cargo-tarpaulin
+      - run: cargo tarpaulin --manifest-path ../Cargo.toml --out Xml --output-dir coverage --fail-under 80
+      - uses: actions/upload-artifact@v3
+        with:
+          name: rust-coverage
+          path: aider-cli/coverage
 
   go:
     runs-on: ubuntu-latest
@@ -33,7 +39,16 @@ jobs:
         with:
           go-version: stable
       - run: go vet ./...
-      - run: go test ./...
+      - run: sudo apt-get update && sudo apt-get install -y bc
+      - run: go test -coverprofile=coverage.out ./...
+      - run: |
+          total=$(go tool cover -func=coverage.out | grep total: | awk '{print substr($3, 1, length($3)-1)}')
+          echo "coverage: $total%"
+          if (( $(echo "$total < 80" | bc -l) )); then exit 1; fi
+      - uses: actions/upload-artifact@v3
+        with:
+          name: go-coverage
+          path: go-shell/coverage.out
 
   dart:
     runs-on: ubuntu-latest
@@ -43,6 +58,18 @@ jobs:
         with:
           channel: stable
       - run: dart analyze dart_cli
-      - run: dart test dart_cli
+      - run: sudo apt-get update && sudo apt-get install -y lcov bc
+      - run: dart pub global activate coverage
+      - run: |
+          dart test --coverage=coverage
+          dart pub global run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info
+          cov=$(awk -F: '/^LH:/{covered+=$2}/^LF:/{total+=$2} END{print covered*100/total}' coverage/lcov.info)
+          echo "coverage: $cov%"
+          if (( $(echo "$cov < 80" | bc -l) )); then exit 1; fi
+        working-directory: dart_cli
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dart-coverage
+          path: dart_cli/coverage
       - run: flutter analyze flutter_app
       - run: flutter test flutter_app

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod voice;
 pub mod watch;
 pub mod watch_prompts;
 pub mod models;
+pub mod udiff;
 pub use aider_llm::{mock::MockProvider, ModelProvider};
 pub use command::Command;
 pub use commit::generate_commit_message;
@@ -40,6 +41,7 @@ pub use onboarding::{check_openrouter_tier, try_to_select_default_model};
 pub use voice::VoiceTranscriber;
 pub use watch::FileWatcher;
 pub use watch_prompts::{watch_ask_prompt, watch_code_prompt};
+pub use udiff::find_diffs;
 
 pub fn init_tracing() -> Result<()> {
     let subscriber = FmtSubscriber::new();

--- a/crates/core/src/udiff.rs
+++ b/crates/core/src/udiff.rs
@@ -1,0 +1,83 @@
+/// Parse fenced unified diff blocks from text and return file edits.
+///
+/// Each edit is returned as a tuple of the file path and the lines in the hunk
+/// (including context and +/- changes, but excluding the `@@` header lines).
+pub fn find_diffs(content: &str) -> Vec<(String, Vec<String>)> {
+    let mut text = content.to_string();
+    if !text.ends_with('\n') {
+        text.push('\n');
+    }
+    let lines: Vec<&str> = text.split_inclusive('\n').collect();
+    let mut i = 0;
+    let mut edits = Vec::new();
+
+    while i < lines.len() {
+        if lines[i].starts_with("```diff") {
+            i += 1; // move past ```diff line
+            let mut block = Vec::new();
+            while i < lines.len() && !lines[i].starts_with("```") {
+                block.push(lines[i].to_string());
+                i += 1;
+            }
+            // skip closing fence if present
+            if i < lines.len() {
+                i += 1;
+            }
+
+            // determine file name from header if present
+            let mut fname = String::new();
+            let mut start = 0usize;
+            if block.len() >= 2 && block[0].starts_with("--- ") && block[1].starts_with("+++ ") {
+                let a_fname = block[0][4..].trim();
+                let b_fname = block[1][4..].trim();
+                if (a_fname.starts_with("a/") || a_fname == "/dev/null") && b_fname.starts_with("b/") {
+                    fname = b_fname[2..].to_string();
+                } else {
+                    fname = b_fname.to_string();
+                }
+                start = 2;
+            }
+
+            // scan for hunks inside the block, accounting for multiple diffs
+            let mut j = start;
+            let mut current_fname = fname.clone();
+            while j < block.len() {
+                if block[j].starts_with("--- ") && j + 1 < block.len() && block[j + 1].starts_with("+++ ") {
+                    let a_fname = block[j][4..].trim();
+                    let b_fname = block[j + 1][4..].trim();
+                    if (a_fname.starts_with("a/") || a_fname == "/dev/null") && b_fname.starts_with("b/") {
+                        current_fname = b_fname[2..].to_string();
+                    } else {
+                        current_fname = b_fname.to_string();
+                    }
+                    j += 2;
+                    continue;
+                }
+                if block[j].starts_with("@@") {
+                    j += 1;
+                    let mut hunk = Vec::new();
+                    while j < block.len()
+                        && !block[j].starts_with("@@")
+                        && !(block[j].starts_with("--- ") && j + 1 < block.len() && block[j + 1].starts_with("+++ "))
+                        && !(block[j].trim().is_empty()
+                            && j + 2 < block.len()
+                            && block[j + 1].starts_with("--- ")
+                            && block[j + 2].starts_with("+++ "))
+                    {
+                        hunk.push(block[j].clone());
+                        j += 1;
+                    }
+                    if !hunk.is_empty() {
+                        edits.push((current_fname.clone(), hunk));
+                    }
+                    continue;
+                }
+                j += 1;
+            }
+        } else {
+            i += 1;
+        }
+    }
+
+    edits
+}

--- a/crates/core/tests/udiff.rs
+++ b/crates/core/tests/udiff.rs
@@ -1,0 +1,103 @@
+use aider_core::find_diffs;
+
+#[test]
+fn find_diffs_single_hunk() {
+    let content = r#"Some text...
+
+```diff
+--- file.txt
++++ file.txt
+@@ ... @@
+-Original
++Modified
+```
+"#;
+    let edits = find_diffs(content);
+    assert_eq!(edits.len(), 1);
+    let edit = &edits[0];
+    assert_eq!(edit.0, "file.txt");
+    assert_eq!(edit.1, vec!["-Original\n".to_string(), "+Modified\n".to_string()]);
+}
+
+#[test]
+fn find_diffs_dev_null() {
+    let content = r#"Some text...
+
+```diff
+--- /dev/null
++++ file.txt
+@@ ... @@
+-Original
++Modified
+```
+"#;
+    let edits = find_diffs(content);
+    assert_eq!(edits.len(), 1);
+    let edit = &edits[0];
+    assert_eq!(edit.0, "file.txt");
+    assert_eq!(edit.1, vec!["-Original\n".to_string(), "+Modified\n".to_string()]);
+}
+
+#[test]
+fn find_diffs_dirname_with_spaces() {
+    let content = r#"Some text...
+
+```diff
+--- dir name with spaces/file.txt
++++ dir name with spaces/file.txt
+@@ ... @@
+-Original
++Modified
+```
+"#;
+    let edits = find_diffs(content);
+    assert_eq!(edits.len(), 1);
+    let edit = &edits[0];
+    assert_eq!(edit.0, "dir name with spaces/file.txt");
+    assert_eq!(edit.1, vec!["-Original\n".to_string(), "+Modified\n".to_string()]);
+}
+
+#[test]
+fn find_multi_diffs() {
+    let content = r#"To implement the `--check-update` option, I will make the following changes:
+
+1. Add the `--check-update` argument to the argument parser in `aider/main.py`.
+2. Modify the `check_version` function in `aider/versioncheck.py` to return a boolean indicating whether an update is available.
+3. Use the returned value from `check_version` in `aider/main.py` to set the exit status code when `--check-update` is used.
+
+Here are the diffs for those changes:
+
+```diff
+--- aider/versioncheck.py
++++ aider/versioncheck.py
+@@ ... @@
+     except Exception as err:
+         print_cmd(f"Error checking pypi for new version: {err}")
++        return False
+
+--- aider/main.py
++++ aider/main.py
+@@ ... @@
+     other_group.add_argument(
+         "--version",
+         action="version",
+         version=f"%(prog)s {__version__}",
+         help="Show the version number and exit",
+     )
++    other_group.add_argument(
++        "--check-update",
++        action="store_true",
++        help="Check for updates and return status in the exit code",
++        default=False,
++    )
+     other_group.add_argument(
+         "--apply",
+         metavar="FILE",
+```
+
+These changes will add the `--check-update` option to the command-line interface and use the `check_version` function to determine if an update is available, exiting with status code `0` if no update is available and `1` if an update is available.
+"#;
+    let edits = find_diffs(content);
+    assert_eq!(edits.len(), 2);
+    assert_eq!(edits[0].1.len(), 3);
+}


### PR DESCRIPTION
## Summary
- add `find_diffs` utility to parse fenced unified diff blocks
- port Python udiff tests to Rust
- measure code coverage in CI with language-specific tools and enforce thresholds

## Testing
- `cargo test -p aider-core --test udiff`
- `cargo tarpaulin -p aider-core --out Xml --output-dir coverage`


------
https://chatgpt.com/codex/tasks/task_b_68aaf3a0475883298d526e5fea33f88e