### PR TITLE
docs: add build/test/coverage guidance

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -18,3 +18,39 @@ invoke Rust sidecars such as `git_sidecar`.  When the variable is not set the
 original Python implementations act as a fallback during the transition.
 
 Progress on this migration should be updated here as milestones are completed.
+
+## Building Components
+
+```bash
+cargo build --workspace
+go build ./go-shell
+dart compile exe dart_cli/bin/aider.dart -o build/dart/aider
+```
+
+## Test Suite
+
+```bash
+cargo test --workspace
+go test ./...
+dart test
+```
+
+## Coverage
+
+Generate coverage reports for each language and compare them across releases to track progress:
+
+```bash
+# Rust coverage
+cargo llvm-cov --workspace --html --output-dir coverage/rust
+
+# Go coverage
+go test ./... -coverprofile=coverage/go.out
+go tool cover -html=coverage/go.out -o coverage/go.html
+
+# Dart coverage
+dart test --coverage=coverage/dart
+format_coverage --lcov --in coverage/dart --out coverage/dart/lcov.info
+
+# Compare coverage across releases
+diff -ru coverage/release-1 coverage/release-2
+```

--- a/README.md
+++ b/README.md
@@ -105,20 +105,24 @@ Work with any LLM via its web chat interface. Aider streamlines copy/pasting cod
 ## Getting Started
 
 ```bash
-python -m pip install aider-install
-aider-install
+
+# Build the Rust command line interface
+cargo install --path aider-cli
+
+# Use the compiled binary
+aider-cli
 
 # Change directory into your codebase
 cd /to/your/project
 
 # DeepSeek
-aider --model deepseek --api-key deepseek=<key>
+aider-cli --model deepseek --api-key deepseek=<key>
 
 # Claude 3.7 Sonnet
-aider --model sonnet --api-key anthropic=<key>
+aider-cli --model sonnet --api-key anthropic=<key>
 
 # o3-mini
-aider --model o3-mini --api-key openai=<key>
+aider-cli --model o3-mini --api-key openai=<key>
 ```
 
 See the [installation instructions](https://aider.chat/docs/install.html) and [usage documentation](https://aider.chat/docs/usage.html) for more details.
@@ -204,10 +208,43 @@ The workspace is organized into the following crates:
 The workspace targets Rust edition 2021 and is configured for
 `cargo fmt` and `cargo clippy` via `rustfmt.toml` and `clippy.toml`.
 
-## Development setup
-
-Install development dependencies to work on the project:
+## Building Components
 
 ```bash
-pip install -r requirements/requirements-dev.txt
+# Rust CLI
+cargo build --workspace
+
+# Go utilities
+go build ./go-shell
+
+# Dart tools
+dart compile exe dart_cli/bin/aider.dart -o build/dart/aider
+```
+
+## Running Tests
+
+```bash
+cargo test --workspace
+go test ./...
+dart test
+```
+
+## Coverage Reports
+
+Generate coverage data for each language and compare results between releases:
+
+```bash
+# Rust coverage
+cargo llvm-cov --workspace --html --output-dir coverage/rust
+
+# Go coverage
+go test ./... -coverprofile=coverage/go.out
+go tool cover -html=coverage/go.out -o coverage/go.html
+
+# Dart coverage
+dart test --coverage=coverage/dart
+format_coverage --lcov --in coverage/dart --out coverage/dart/lcov.info
+
+# Compare coverage across releases
+diff -ru coverage/release-1 coverage/release-2
 ```


### PR DESCRIPTION
## Summary
- document compiling the Rust CLI and using `aider-cli`
- add build and test commands for Rust, Go, and Dart components
- explain how to generate and compare coverage reports across releases

## Testing
- `cargo test --workspace` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*
- `go test ./...` *(fails: pattern ./... does not contain a main module or dependencies)*
- `dart test` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_b_68ab56e674bc832983ea3d26c69edd09